### PR TITLE
Add CocoaPods podspec

### DIFF
--- a/SVProgressHUD.podspec
+++ b/SVProgressHUD.podspec
@@ -1,0 +1,20 @@
+Pod::Spec.new do |s|
+  s.name     = 'SVProgressHUD'
+  s.version  = '0.1'
+  s.platform = :ios
+  s.license  = 'MIT'
+  s.summary  = 'A clean and lightweight progress HUD for your iOS app.'
+  s.homepage = 'http://samvermette.com/199'
+  s.author   = { 'Sam Vermette' => 'samvermette@gmail.com' }
+  s.source   = { :git => 'https://github.com/samvermette/SVProgressHUD.git', :tag => '0.1' }
+
+  s.description = 'SVProgressHUD is a clean, lightweight and unobtrusive progress HUD for iOS. ' \
+                  'It’s a simplified and prettified alternative to the popular MBProgressHUD. '  \
+                  'Its fade in/out animations are highly inspired on Lauren Britcher’s HUD in '  \
+                  'Tweetie for iOS. The success and error icons are from Glyphish.'
+
+  s.source_files = 'SVProgressHUD/*.{h,m}'
+  s.clean_paths  = 'Demo'
+  s.framework    = 'QuartzCore'
+  s.resources    = 'SVProgressHUD/SVProgressHUD.bundle'
+end


### PR DESCRIPTION
I recently added SVProgressHUD to the [CocoaPods](https://github.com/CocoaPods/CocoaPods) package manager.

Since SVProgressHUD doesn't currently have a discreet version, I treated [the current commit](https://github.com/CocoaPods/Specs/blob/master/SVProgressHUD/0.1/SVProgressHUD.podspec#L10) as the 0.1 release. Would it be possible to have your most recent commit tagged as 0.1 (or whatever version you feel comfortable with)? This will help greatly in dependency resolution.

Finally, this pull request adds the pod spec to the repo as well. Adding this will allow users to install an unreleased version directly from your repo. It also allows you to more easily keep the spec up-to-date with any possible changes, instead of having to remember it all when releasing a new version.

Thanks!
