### PR TITLE
Setting proper previousKeyWindow

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -466,10 +466,14 @@ static SVProgressHUD *sharedView = nil;
                              
                              // find the frontmost window that is an actual UIWindow and make it keyVisible
                              [[UIApplication sharedApplication].windows enumerateObjectsWithOptions:NSEnumerationReverse usingBlock:^(id window, NSUInteger idx, BOOL *stop) {
-                                 if([window isMemberOfClass:[UIWindow class]]) {
-                                     [window makeKeyWindow];
-                                     *stop = YES;
+                                 
+                                 if([window isKindOfClass:[UIWindow class]]) {
+                                     if(((UIWindow*)window).windowLevel == UIWindowLevelNormal) {
+                                         [window makeKeyWindow];
+                                         *stop = YES;
+                                     }
                                  }
+                                 
                              }];
 
                              // uncomment to make sure UIWindow is gone from app.windows


### PR DESCRIPTION
In ver 0.5, there was a property called 'previousKeyWindow' 
to safely go back to the original window after HUD dimissed,
but current code seems to have an issue in finding proper original window.

I found it when I was using my custom window subclass as follows,
and I made a quick fix.

https://github.com/inamiy/YIDetectWindow

(this window adds additional UIWindow for detectinig status-bar tap)
