### PR TITLE
Position of Success/Error images

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -209,7 +209,10 @@ static SVProgressHUD *sharedView = nil;
 	
 	self.hudView.bounds = CGRectMake(0, 0, hudWidth, hudHeight);
 	
-	self.imageView.center = CGPointMake(CGRectGetWidth(self.hudView.bounds)/2, 36);
+    if(string)
+        self.imageView.center = CGPointMake(CGRectGetWidth(self.hudView.bounds)/2, 36);
+	else
+       	self.imageView.center = CGPointMake(CGRectGetWidth(self.hudView.bounds)/2, CGRectGetHeight(self.hudView.bounds)/2);
 	
 	self.stringLabel.hidden = NO;
 	self.stringLabel.text = string;


### PR DESCRIPTION
When using SVProgressHUD with no status text and switching between the activity spinner and the success/error image, the success/error image would not be in the same position as the spinner.
Fixed that using the same code used for the activity spinner position.
