### PR TITLE
Added functions that allow for the use of custom UIImages in the HUD

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -11,6 +11,7 @@ SVProgressHUD features:
 * optional loading, success and error status messages
 * automatic positioning based on device type, orientation and keyboard visibility
 * optionally disable user interactions while the HUD is showing with the @maskType@ parameter
+* optionally use your own 28x28 px UIImage in the HUD
 
 h2. Installation
 
@@ -30,6 +31,7 @@ SVProgressHUD is created as a singleton (i.e. it doesn't need to be explicitly a
 + (void)showWithStatus:(NSString*)status;
 + (void)showWithStatus:(NSString*)status maskType:(SVProgressHUDMaskType)maskType;
 + (void)showWithMaskType:(SVProgressHUDMaskType)maskType;
++ (void)showWithStatus:(NSString *)status image:(UIImage *)image;
 </pre>
 
 You dismiss it using one of these:

--- a/SVProgressHUD/SVProgressHUD.h
+++ b/SVProgressHUD/SVProgressHUD.h
@@ -31,6 +31,9 @@ typedef NSUInteger SVProgressHUDMaskType;
 + (void)showErrorWithStatus:(NSString *)string;
 + (void)showErrorWithStatus:(NSString *)string duration:(NSTimeInterval)duration;
 
++ (void)showWithStatus:(NSString *)status image:(UIImage *)image;
++ (void)showWithStatus:(NSString *)status image:(UIImage *)image duration:(NSTimeInterval)duration;
+
 + (void)setStatus:(NSString*)string; // change the HUD loading status while it's showing
 
 + (void)dismiss; // simply dismiss the HUD with a fade+scale out animation

--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -32,6 +32,7 @@
 - (void)dismiss;
 - (void)dismissWithStatus:(NSString*)string error:(BOOL)error;
 - (void)dismissWithStatus:(NSString*)string error:(BOOL)error afterDelay:(NSTimeInterval)seconds;
+- (void)dismissWithStatus:(NSString*)string error:(BOOL)error afterDelay:(NSTimeInterval)seconds image:(UIImage*)image;
 
 @end
 
@@ -94,6 +95,14 @@
     [SVProgressHUD dismissWithError:string afterDelay:duration];
 }
 
++ (void)showWithStatus:(NSString *)status image:(UIImage *)image {
+    [SVProgressHUD showWithStatus:status image:image duration:1];
+}
+
++ (void)showWithStatus:(NSString *)status image:(UIImage *)image duration:(NSTimeInterval)duration {
+    [SVProgressHUD show];
+    [[SVProgressHUD sharedView] dismissWithStatus:status error:NO afterDelay:duration image:image];
+}
 
 #pragma mark - Dismiss Methods
 
@@ -379,14 +388,23 @@
 
 
 - (void)dismissWithStatus:(NSString *)string error:(BOOL)error afterDelay:(NSTimeInterval)seconds {
+    [self dismissWithStatus:string error:error afterDelay:seconds image:nil];
+}
+
+
+- (void)dismissWithStatus:(NSString *)string error:(BOOL)error afterDelay:(NSTimeInterval)seconds image:(UIImage *)image {
     dispatch_async(dispatch_get_main_queue(), ^{
         if(self.alpha != 1)
             return;
         
-        if(error)
-            self.imageView.image = [UIImage imageNamed:@"SVProgressHUD.bundle/error.png"];
-        else
-            self.imageView.image = [UIImage imageNamed:@"SVProgressHUD.bundle/success.png"];
+        if (!image) {
+            if(error)
+                self.imageView.image = [UIImage imageNamed:@"SVProgressHUD.bundle/error.png"];
+            else
+                self.imageView.image = [UIImage imageNamed:@"SVProgressHUD.bundle/success.png"];
+        } else {
+            self.imageView.image = image;
+        }
         
         self.imageView.hidden = NO;
         [self setStatus:string];


### PR DESCRIPTION
I thought that having only the two default "error" and "success" images was very limiting, so here's a patch that allows users to specify their own UIImages.

Let me know if you have any comments etc.
