### PR TITLE
Fix the inability to interact with the app after dismissing the HUD

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -420,7 +420,7 @@
                                  
                                  [windows enumerateObjectsWithOptions:NSEnumerationReverse usingBlock:^(UIWindow *window, NSUInteger idx, BOOL *stop) {
                                    if([window isKindOfClass:[UIWindow class]] && window.windowLevel == UIWindowLevelNormal) {
-                                     [window makeKeyWindow];
+                                     [window makeKeyAndVisible];
                                      *stop = YES;
                                    }
                                  }];


### PR DESCRIPTION
In some cases, after dismissing the HUD the user couldn't interact with the view as if the main window didn't become active. This patch fixes the issue.
