### PR TITLE
Add ARC compilation check.

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -10,6 +10,10 @@
 #import "SVProgressHUD.h"
 #import <QuartzCore/QuartzCore.h>
 
+#if ! __has_feature(objc_arc)
+#error This file must be compiled with ARC.
+#endif
+
 @interface SVProgressHUD ()
 
 @property (nonatomic, readwrite) SVProgressHUDMaskType maskType;


### PR DESCRIPTION
I've seen some problems around where people try to compile `SVProgressHUD` without ARC, leading to disasters. This commit adds a compiler check so that if ARC isn't used during compilation of the file, it will give an error.
