### PR TITLE
No way to stack progress activity views

### DIFF
--- a/Demo/Classes/ViewController.h
+++ b/Demo/Classes/ViewController.h
@@ -17,5 +17,8 @@
 - (IBAction)dismissSuccess;
 - (IBAction)dismissError;
 
+- (IBAction)pushActivity;
+- (IBAction)popActivity;
+
 @end
 

--- a/Demo/Classes/ViewController.m
+++ b/Demo/Classes/ViewController.m
@@ -43,4 +43,16 @@
 	[SVProgressHUD showErrorWithStatus:@"Failed with Error"];
 }
 
+
+#pragma mark -
+#pragma mark Activity Counter Methods Sample
+
+- (void)pushActivity {
+    [SVProgressHUD pushActivity];
+}
+
+- (void)popActivity {
+    [SVProgressHUD popActivity];
+}
+
 @end

--- a/Demo/ViewController.xib
+++ b/Demo/ViewController.xib
@@ -3,18 +3,18 @@
 	<data>
 		<int key="IBDocument.SystemTarget">1296</int>
 		<string key="IBDocument.SystemVersion">11E53</string>
-		<string key="IBDocument.InterfaceBuilderVersion">2182</string>
+		<string key="IBDocument.InterfaceBuilderVersion">2549</string>
 		<string key="IBDocument.AppKitVersion">1138.47</string>
 		<string key="IBDocument.HIToolboxVersion">569.00</string>
 		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-			<string key="NS.object.0">1179</string>
+			<string key="NS.object.0">1498</string>
 		</object>
 		<object class="NSArray" key="IBDocument.IntegratedClassDependencies">
 			<bool key="EncodedWithXMLCoder">YES</bool>
 			<string>IBProxyObject</string>
-			<string>IBUIView</string>
 			<string>IBUIButton</string>
+			<string>IBUIView</string>
 		</object>
 		<object class="NSArray" key="IBDocument.PluginDependencies">
 			<bool key="EncodedWithXMLCoder">YES</bool>
@@ -42,7 +42,7 @@
 					<object class="IBUIButton" id="820611637">
 						<reference key="NSNextResponder" ref="126585098"/>
 						<int key="NSvFlags">301</int>
-						<string key="NSFrame">{{30, 141}, {260, 44}}</string>
+						<string key="NSFrame">{{30, 72}, {260, 44}}</string>
 						<reference key="NSSuperview" ref="126585098"/>
 						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="670046422"/>
@@ -79,7 +79,7 @@
 					<object class="IBUIButton" id="341658994">
 						<reference key="NSNextResponder" ref="126585098"/>
 						<int key="NSvFlags">301</int>
-						<string key="NSFrame">{{30, 77}, {260, 44}}</string>
+						<string key="NSFrame">{{30, 20}, {260, 44}}</string>
 						<reference key="NSSuperview" ref="126585098"/>
 						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="820611637"/>
@@ -101,7 +101,7 @@
 					<object class="IBUIButton" id="670046422">
 						<reference key="NSNextResponder" ref="126585098"/>
 						<int key="NSvFlags">301</int>
-						<string key="NSFrame">{{30, 236}, {260, 44}}</string>
+						<string key="NSFrame">{{30, 156}, {260, 44}}</string>
 						<reference key="NSSuperview" ref="126585098"/>
 						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="111285255"/>
@@ -123,7 +123,7 @@
 					<object class="IBUIButton" id="111285255">
 						<reference key="NSNextResponder" ref="126585098"/>
 						<int key="NSvFlags">301</int>
-						<string key="NSFrame">{{30, 300}, {260, 44}}</string>
+						<string key="NSFrame">{{30, 208}, {260, 44}}</string>
 						<reference key="NSSuperview" ref="126585098"/>
 						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="643745546"/>
@@ -145,16 +145,58 @@
 					<object class="IBUIButton" id="643745546">
 						<reference key="NSNextResponder" ref="126585098"/>
 						<int key="NSvFlags">301</int>
-						<string key="NSFrame">{{30, 364}, {260, 44}}</string>
+						<string key="NSFrame">{{30, 260}, {260, 44}}</string>
 						<reference key="NSSuperview" ref="126585098"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView"/>
 						<bool key="IBUIOpaque">NO</bool>
 						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
 						<int key="IBUIContentHorizontalAlignment">0</int>
 						<int key="IBUIContentVerticalAlignment">0</int>
 						<int key="IBUIButtonType">1</int>
 						<string key="IBUINormalTitle">showErrorWithStatus:</string>
+						<reference key="IBUIHighlightedTitleColor" ref="524652865"/>
+						<object class="NSColor" key="IBUINormalTitleColor">
+							<int key="NSColorSpace">1</int>
+							<bytes key="NSRGB">MC4xOTYwNzg0MzQ2IDAuMzA5ODAzOTMyOSAwLjUyMTU2ODY1NgA</bytes>
+						</object>
+						<reference key="IBUINormalTitleShadowColor" ref="934167192"/>
+						<reference key="IBUIFontDescription" ref="145541768"/>
+						<reference key="IBUIFont" ref="122504481"/>
+					</object>
+					<object class="IBUIButton" id="74414262">
+						<reference key="NSNextResponder" ref="126585098"/>
+						<int key="NSvFlags">301</int>
+						<string key="NSFrame">{{30, 344}, {260, 44}}</string>
+						<reference key="NSSuperview" ref="126585098"/>
+						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="59307849"/>
+						<bool key="IBUIOpaque">NO</bool>
+						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+						<int key="IBUIContentHorizontalAlignment">0</int>
+						<int key="IBUIContentVerticalAlignment">0</int>
+						<int key="IBUIButtonType">1</int>
+						<string key="IBUINormalTitle">pushActivity</string>
+						<reference key="IBUIHighlightedTitleColor" ref="524652865"/>
+						<object class="NSColor" key="IBUINormalTitleColor">
+							<int key="NSColorSpace">1</int>
+							<bytes key="NSRGB">MC4xOTYwNzg0MzQ2IDAuMzA5ODAzOTMyOSAwLjUyMTU2ODY1NgA</bytes>
+						</object>
+						<reference key="IBUINormalTitleShadowColor" ref="934167192"/>
+						<reference key="IBUIFontDescription" ref="145541768"/>
+						<reference key="IBUIFont" ref="122504481"/>
+					</object>
+					<object class="IBUIButton" id="59307849">
+						<reference key="NSNextResponder" ref="126585098"/>
+						<int key="NSvFlags">301</int>
+						<string key="NSFrame">{{30, 396}, {260, 44}}</string>
+						<reference key="NSSuperview" ref="126585098"/>
+						<reference key="NSWindow"/>
+						<bool key="IBUIOpaque">NO</bool>
+						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+						<int key="IBUIContentHorizontalAlignment">0</int>
+						<int key="IBUIContentVerticalAlignment">0</int>
+						<int key="IBUIButtonType">1</int>
+						<string key="IBUINormalTitle">popAcitivity</string>
 						<reference key="IBUIHighlightedTitleColor" ref="524652865"/>
 						<object class="NSColor" key="IBUINormalTitleColor">
 							<int key="NSColorSpace">1</int>
@@ -232,6 +274,24 @@
 					</object>
 					<int key="connectionID">17</int>
 				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchEventConnection" key="connection">
+						<string key="label">pushActivity</string>
+						<reference key="source" ref="74414262"/>
+						<reference key="destination" ref="372490531"/>
+						<int key="IBEventType">7</int>
+					</object>
+					<int key="connectionID">31</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchEventConnection" key="connection">
+						<string key="label">popActivity</string>
+						<reference key="source" ref="59307849"/>
+						<reference key="destination" ref="372490531"/>
+						<int key="IBEventType">7</int>
+					</object>
+					<int key="connectionID">33</int>
+				</object>
 			</object>
 			<object class="IBMutableOrderedSet" key="objectRecords">
 				<object class="NSArray" key="orderedObjects">
@@ -265,6 +325,8 @@
 							<reference ref="670046422"/>
 							<reference ref="111285255"/>
 							<reference ref="643745546"/>
+							<reference ref="74414262"/>
+							<reference ref="59307849"/>
 						</object>
 						<reference key="parent" ref="0"/>
 					</object>
@@ -293,6 +355,16 @@
 						<reference key="object" ref="643745546"/>
 						<reference key="parent" ref="126585098"/>
 					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">27</int>
+						<reference key="object" ref="74414262"/>
+						<reference key="parent" ref="126585098"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">28</int>
+						<reference key="object" ref="59307849"/>
+						<reference key="parent" ref="126585098"/>
+					</object>
 				</object>
 			</object>
 			<object class="NSMutableDictionary" key="flattenedProperties">
@@ -307,6 +379,8 @@
 					<string>13.IBPluginDependency</string>
 					<string>14.IBPluginDependency</string>
 					<string>15.IBPluginDependency</string>
+					<string>27.IBPluginDependency</string>
+					<string>28.IBPluginDependency</string>
 					<string>8.IBPluginDependency</string>
 					<string>9.IBPluginDependency</string>
 				</object>
@@ -315,6 +389,8 @@
 					<string>ViewController</string>
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 					<string>UIResponder</string>
+					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
@@ -336,7 +412,7 @@
 				<reference key="dict.values" ref="0"/>
 			</object>
 			<nil key="sourceID"/>
-			<int key="maxID">26</int>
+			<int key="maxID">33</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<object class="NSMutableArray" key="referencedPartialClassDescriptions">
@@ -351,11 +427,15 @@
 							<string>dismiss</string>
 							<string>dismissError</string>
 							<string>dismissSuccess</string>
+							<string>popActivity</string>
+							<string>pushActivity</string>
 							<string>show</string>
 							<string>showWithStatus</string>
 						</object>
 						<object class="NSArray" key="dict.values">
 							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>id</string>
+							<string>id</string>
 							<string>id</string>
 							<string>id</string>
 							<string>id</string>
@@ -370,6 +450,8 @@
 							<string>dismiss</string>
 							<string>dismissError</string>
 							<string>dismissSuccess</string>
+							<string>popActivity</string>
+							<string>pushActivity</string>
 							<string>show</string>
 							<string>showWithStatus</string>
 						</object>
@@ -385,6 +467,14 @@
 							</object>
 							<object class="IBActionInfo">
 								<string key="name">dismissSuccess</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">popActivity</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">pushActivity</string>
 								<string key="candidateClassName">id</string>
 							</object>
 							<object class="IBActionInfo">
@@ -416,6 +506,6 @@
 		</object>
 		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
 		<int key="IBDocument.defaultPropertyAccessControl">3</int>
-		<string key="IBCocoaTouchPluginVersion">1179</string>
+		<string key="IBCocoaTouchPluginVersion">1498</string>
 	</data>
 </archive>

--- a/SVProgressHUD/SVProgressHUD.h
+++ b/SVProgressHUD/SVProgressHUD.h
@@ -38,6 +38,10 @@ typedef NSUInteger SVProgressHUDMaskType;
 
 + (BOOL)isVisible;
 
++ (void)pushActivity;
++ (void)popActivity;
++ (void)resetActivity;
+
 
 // deprecated June 9th; custom durations encourages uncessarily long status strings (inappropriate, use UIAlertView instead)
 + (void)showSuccessWithStatus:(NSString *)string duration:(NSTimeInterval)duration DEPRECATED_ATTRIBUTE;

--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -10,6 +10,7 @@
 #import "SVProgressHUD.h"
 #import <QuartzCore/QuartzCore.h>
 
+
 #if ! __has_feature(objc_arc)
 #error You need to either convert your project to ARC or add the -fobjc-arc compiler flag to SVProgressHUD.m.
 #endif
@@ -42,6 +43,8 @@
 @implementation SVProgressHUD
 
 @synthesize overlayWindow, hudView, maskType, fadeOutTimer, stringLabel, imageView, spinnerView, visibleKeyboardHeight;
+
+static NSInteger activityCount;
 
 - (void)dealloc {
 	self.fadeOutTimer = nil;
@@ -423,6 +426,56 @@
                          }];
     });
 }
+
+- (NSInteger)activityCount {
+    @synchronized([SVProgressHUD sharedView]) {
+        return activityCount;
+    }
+}
+
+- (void)refreshActivityIndicator {
+    if(![NSThread isMainThread]) {
+        SEL sel_refresh = @selector(refreshActivityIndicator);
+        [self performSelectorOnMainThread:sel_refresh withObject:nil waitUntilDone:NO];
+        return;
+    }
+    BOOL active = (self.activityCount > 0);
+    if (active) {
+        if ([SVProgressHUD isVisible]) {
+            return;
+        } else {
+            [SVProgressHUD show];
+        }
+    } else {
+        [SVProgressHUD dismiss];
+    }
+}
+
++ (void)pushActivity {
+    @synchronized([SVProgressHUD sharedView]) {
+        activityCount++;
+    }
+    [[SVProgressHUD sharedView] refreshActivityIndicator];
+}
+
++ (void)popActivity {
+    @synchronized([SVProgressHUD sharedView]) {
+        if (activityCount > 0) {
+            activityCount--;
+        } else {
+            activityCount = 0;
+        }
+    }
+    [[SVProgressHUD sharedView] refreshActivityIndicator];
+}
+
++ (void)resetActivity {
+    @synchronized([SVProgressHUD sharedView]) {
+        activityCount = 0;
+    }
+    [[SVProgressHUD sharedView] refreshActivityIndicator];
+}
+
 
 #pragma mark - Utilities
 


### PR DESCRIPTION
When sending off multiple async requests it's nice to be able to stack
activity indicators instead of keeping track of when all the async
requests have finished then dismissing the activity indicator.

I also updated the example.

I basically copied the way RestKit handles the networkActivityView spinner.
