### PR TITLE
Schedule the timer in the common run loop modes.

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -392,7 +392,8 @@
         [self setStatus:string];
         [self.spinnerView stopAnimating];
         
-        self.fadeOutTimer = [NSTimer scheduledTimerWithTimeInterval:duration target:self selector:@selector(dismiss) userInfo:nil repeats:NO];
+        self.fadeOutTimer = [NSTimer timerWithTimeInterval:duration target:self selector:@selector(dismiss) userInfo:nil repeats:NO];
+        [[NSRunLoop mainRunLoop] addTimer:self.fadeOutTimer forMode:NSRunLoopCommonModes];
     });
 }
 


### PR DESCRIPTION
Previously, the fade out timer was being added to the default run loop
(as a side effect of +scheduledTimerWithTimeInterval:).  This caused
the timer to "freeze" while user events were being tracked (such as
while scrolling or handling touches).

Fixes #94.
