### PR TITLE
Update SVProgressHUD.podspec

### DIFF
--- a/SVProgressHUD.podspec
+++ b/SVProgressHUD.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |s|
   s.name     = 'SVProgressHUD'
-  s.version  = '0.6'
+  s.version  = '0.8'
   s.platform = :ios
   s.license  = 'MIT'
   s.summary  = 'A clean and lightweight progress HUD for your iOS app.'
   s.homepage = 'http://samvermette.com/199'
   s.author   = { 'Sam Vermette' => 'hello@samvermette.com' }
-  s.source   = { :git => 'https://github.com/samvermette/SVProgressHUD.git', :tag => '0.6' }
+  s.source   = { :git => 'https://github.com/samvermette/SVProgressHUD.git', :commit => '35f39d978ba37706ca56ff90f08f9558dbb172f5' }
 
   s.description = 'SVProgressHUD is an easy-to-use, clean and lightweight progress HUD for iOS. ' \
                   'It’s a simplified and prettified alternative to the popular MBProgressHUD. '  \
@@ -17,4 +17,5 @@ Pod::Spec.new do |s|
   s.clean_paths  = 'Demo'
   s.framework    = 'QuartzCore'
   s.resources    = 'SVProgressHUD/SVProgressHUD.bundle'
+  s.requires_arc = true
 end


### PR DESCRIPTION
The latest version on Cocoapods is 0.7, which is about 5 months old (and pre-ARC, to boot.) I created a mythical version 0.8 based on the latest commit.
