### PR TITLE
Set accessibility label and element

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -351,23 +351,20 @@
     
     if(self.maskType != SVProgressHUDMaskTypeNone) {
         self.overlayWindow.userInteractionEnabled = YES;
+        self.accessibilityLabel = string;
+        self.isAccessibilityElement = YES;
     } else {
         self.overlayWindow.userInteractionEnabled = NO;
+        self.hudView.accessibilityLabel = string;
+        self.hudView.isAccessibilityElement = YES;
     }
-    
+
     [self.overlayWindow setHidden:NO];
     [self positionHUD:nil];
     
     if(self.alpha != 1) {
         [self registerNotifications];
         self.hudView.transform = CGAffineTransformScale(self.hudView.transform, 1.3, 1.3);
-        if (self.maskType == SVProgressHUDMaskTypeNone) {
-            self.hudView.accessibilityLabel = string;
-            self.hudView.isAccessibilityElement = YES;
-        } else {
-            self.accessibilityLabel = string;
-            self.isAccessibilityElement = YES;
-        }
 
         [UIView animateWithDuration:0.15
                               delay:0


### PR DESCRIPTION
I've only done limited testing, but for me this works as expected. One issue is that no accessibility label is set when there's no status message. Maybe there should be a default such as "Loading" or something similar.

If the SVProgressHUDMaskType doesn't allow any user interaction, the whole view is set as the accessibility element, so if the user taps anywhere on the screen while the progress hud is shown, the status message is announced by Voice Over.
If the mask type is SVProgressHUDMaskTypeNone only the hud view is set as the accessibility element.

When showing the hud, Voice Over announces the status message.
