### PR TITLE
Ensure HUD overlayWindow is visible above other windows.

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -438,6 +438,7 @@
         overlayWindow.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
         overlayWindow.backgroundColor = [UIColor clearColor];
         overlayWindow.userInteractionEnabled = NO;
+        overlayWindow.windowLevel = UIWindowLevelStatusBar;
     }
     return overlayWindow;
 }


### PR DESCRIPTION
Even without creating other windows, in some cases (it depends on how iOS is displaying the windows) the HUD's overlayWindow won't be visible. The display of windows with the same level doesn't appear to be guaranteed, so we should position the HUD at a higher level to guarantee visibility.
