### PR TITLE
Usable with NULL image

### DIFF
--- a/Demo/Classes/ViewController.h
+++ b/Demo/Classes/ViewController.h
@@ -12,7 +12,6 @@
 
 - (IBAction)show;
 - (IBAction)showWithStatus;
-- (IBAction)showWithTextOnlyStatus;
 
 - (IBAction)dismiss;
 - (IBAction)dismissSuccess;

--- a/Demo/Classes/ViewController.m
+++ b/Demo/Classes/ViewController.m
@@ -29,10 +29,6 @@
 	[SVProgressHUD showWithStatus:@"Doing Stuff"];
 }
 
-- (void)showWithTextOnlyStatus {
-    [SVProgressHUD showImage:nil status:@"Just some text"];
-}
-
 static float progress = 0.0f;
 - (IBAction)showWithProgress:(id)sender {
     progress = 0.0f;

--- a/Demo/ViewController.xib
+++ b/Demo/ViewController.xib
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <archive type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="7.10">
 	<data>
-		<int key="IBDocument.SystemTarget">1296</int>
-		<string key="IBDocument.SystemVersion">11G63</string>
-		<string key="IBDocument.InterfaceBuilderVersion">2549</string>
-		<string key="IBDocument.AppKitVersion">1138.51</string>
-		<string key="IBDocument.HIToolboxVersion">569.00</string>
+		<int key="IBDocument.SystemTarget">1536</int>
+		<string key="IBDocument.SystemVersion">12C60</string>
+		<string key="IBDocument.InterfaceBuilderVersion">2844</string>
+		<string key="IBDocument.AppKitVersion">1187.34</string>
+		<string key="IBDocument.HIToolboxVersion">625.00</string>
 		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-			<string key="NS.object.0">1498</string>
+			<string key="NS.object.0">1930</string>
 		</object>
 		<object class="NSArray" key="IBDocument.IntegratedClassDependencies">
 			<bool key="EncodedWithXMLCoder">YES</bool>
@@ -42,10 +42,10 @@
 					<object class="IBUIButton" id="820611637">
 						<reference key="NSNextResponder" ref="126585098"/>
 						<int key="NSvFlags">301</int>
-						<string key="NSFrame">{{30, 84}, {260, 44}}</string>
+						<string key="NSFrame">{{30, 91}, {260, 44}}</string>
 						<reference key="NSSuperview" ref="126585098"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="997750696"/>
+						<reference key="NSNextKeyView" ref="670046422"/>
 						<bool key="IBUIOpaque">NO</bool>
 						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
 						<int key="IBUIContentHorizontalAlignment">0</int>
@@ -79,7 +79,7 @@
 					<object class="IBUIButton" id="341658994">
 						<reference key="NSNextResponder" ref="126585098"/>
 						<int key="NSvFlags">301</int>
-						<string key="NSFrame">{{30, 20}, {260, 44}}</string>
+						<string key="NSFrame">{{30, 27}, {260, 44}}</string>
 						<reference key="NSSuperview" ref="126585098"/>
 						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="820611637"/>
@@ -101,7 +101,7 @@
 					<object class="IBUIButton" id="670046422">
 						<reference key="NSNextResponder" ref="126585098"/>
 						<int key="NSvFlags">301</int>
-						<string key="NSFrame">{{30, 268}, {260, 44}}</string>
+						<string key="NSFrame">{{30, 236}, {260, 44}}</string>
 						<reference key="NSSuperview" ref="126585098"/>
 						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="111285255"/>
@@ -123,7 +123,7 @@
 					<object class="IBUIButton" id="111285255">
 						<reference key="NSNextResponder" ref="126585098"/>
 						<int key="NSvFlags">301</int>
-						<string key="NSFrame">{{30, 332}, {260, 44}}</string>
+						<string key="NSFrame">{{30, 300}, {260, 44}}</string>
 						<reference key="NSSuperview" ref="126585098"/>
 						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="643745546"/>
@@ -145,10 +145,9 @@
 					<object class="IBUIButton" id="643745546">
 						<reference key="NSNextResponder" ref="126585098"/>
 						<int key="NSvFlags">301</int>
-						<string key="NSFrame">{{30, 396}, {260, 44}}</string>
+						<string key="NSFrame">{{30, 364}, {260, 44}}</string>
 						<reference key="NSSuperview" ref="126585098"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView"/>
 						<bool key="IBUIOpaque">NO</bool>
 						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
 						<int key="IBUIContentHorizontalAlignment">0</int>
@@ -167,33 +166,10 @@
 					<object class="IBUIButton" id="997750696">
 						<reference key="NSNextResponder" ref="126585098"/>
 						<int key="NSvFlags">301</int>
-						<string key="NSFrame">{{30, 148}, {260, 44}}</string>
+						<string key="NSFrame">{{30, 155}, {260, 44}}</string>
 						<reference key="NSSuperview" ref="126585098"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="442267834"/>
-						<string key="NSReuseIdentifierKey">_NS:9</string>
-						<bool key="IBUIOpaque">NO</bool>
-						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-						<int key="IBUIContentHorizontalAlignment">0</int>
-						<int key="IBUIContentVerticalAlignment">0</int>
-						<int key="IBUIButtonType">1</int>
-						<string key="IBUINormalTitle">showWithStatus: (text)</string>
-						<reference key="IBUIHighlightedTitleColor" ref="524652865"/>
-						<object class="NSColor" key="IBUINormalTitleColor">
-							<int key="NSColorSpace">1</int>
-							<bytes key="NSRGB">MC4xOTYwNzg0MzQ2IDAuMzA5ODAzOTMyOSAwLjUyMTU2ODY1NgA</bytes>
-						</object>
-						<reference key="IBUINormalTitleShadowColor" ref="934167192"/>
-						<reference key="IBUIFontDescription" ref="145541768"/>
-						<reference key="IBUIFont" ref="122504481"/>
-					</object>
-					<object class="IBUIButton" id="442267834">
-						<reference key="NSNextResponder" ref="126585098"/>
-						<int key="NSvFlags">301</int>
-						<string key="NSFrame">{{30, 208}, {260, 44}}</string>
-						<reference key="NSSuperview" ref="126585098"/>
-						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="670046422"/>
+						<reference key="NSNextKeyView" ref="341658994"/>
 						<string key="NSReuseIdentifierKey">_NS:9</string>
 						<bool key="IBUIOpaque">NO</bool>
 						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
@@ -214,7 +190,7 @@
 				<string key="NSFrameSize">{320, 460}</string>
 				<reference key="NSSuperview"/>
 				<reference key="NSWindow"/>
-				<reference key="NSNextKeyView" ref="341658994"/>
+				<reference key="NSNextKeyView" ref="997750696"/>
 				<object class="NSColor" key="IBUIBackgroundColor">
 					<int key="NSColorSpace">3</int>
 					<bytes key="NSWhite">MC45AA</bytes>
@@ -280,21 +256,12 @@
 				</object>
 				<object class="IBConnectionRecord">
 					<object class="IBCocoaTouchEventConnection" key="connection">
-						<string key="label">showWithTextOnlyStatus</string>
+						<string key="label">showWithProgress:</string>
 						<reference key="source" ref="997750696"/>
 						<reference key="destination" ref="372490531"/>
 						<int key="IBEventType">7</int>
 					</object>
-					<int key="connectionID">32</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBCocoaTouchEventConnection" key="connection">
-						<string key="label">showWithProgress:</string>
-						<reference key="source" ref="442267834"/>
-						<reference key="destination" ref="372490531"/>
-						<int key="IBEventType">7</int>
-					</object>
-					<int key="connectionID">31</int>
+					<int key="connectionID">29</int>
 				</object>
 			</object>
 			<object class="IBMutableOrderedSet" key="objectRecords">
@@ -324,13 +291,12 @@
 						<reference key="object" ref="126585098"/>
 						<object class="NSMutableArray" key="children">
 							<bool key="EncodedWithXMLCoder">YES</bool>
+							<reference ref="341658994"/>
+							<reference ref="820611637"/>
 							<reference ref="670046422"/>
 							<reference ref="111285255"/>
 							<reference ref="643745546"/>
-							<reference ref="820611637"/>
-							<reference ref="341658994"/>
 							<reference ref="997750696"/>
-							<reference ref="442267834"/>
 						</object>
 						<reference key="parent" ref="0"/>
 					</object>
@@ -364,11 +330,6 @@
 						<reference key="object" ref="997750696"/>
 						<reference key="parent" ref="126585098"/>
 					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">30</int>
-						<reference key="object" ref="442267834"/>
-						<reference key="parent" ref="126585098"/>
-					</object>
 				</object>
 			</object>
 			<object class="NSMutableDictionary" key="flattenedProperties">
@@ -384,7 +345,6 @@
 					<string>14.IBPluginDependency</string>
 					<string>15.IBPluginDependency</string>
 					<string>27.IBPluginDependency</string>
-					<string>30.IBPluginDependency</string>
 					<string>8.IBPluginDependency</string>
 					<string>9.IBPluginDependency</string>
 				</object>
@@ -393,7 +353,6 @@
 					<string>ViewController</string>
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 					<string>UIResponder</string>
-					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
@@ -416,7 +375,7 @@
 				<reference key="dict.values" ref="0"/>
 			</object>
 			<nil key="sourceID"/>
-			<int key="maxID">32</int>
+			<int key="maxID">29</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<object class="NSMutableArray" key="referencedPartialClassDescriptions">
@@ -434,11 +393,9 @@
 							<string>show</string>
 							<string>showWithProgress:</string>
 							<string>showWithStatus</string>
-							<string>showWithTextOnlyStatus</string>
 						</object>
 						<object class="NSArray" key="dict.values">
 							<bool key="EncodedWithXMLCoder">YES</bool>
-							<string>id</string>
 							<string>id</string>
 							<string>id</string>
 							<string>id</string>
@@ -457,7 +414,6 @@
 							<string>show</string>
 							<string>showWithProgress:</string>
 							<string>showWithStatus</string>
-							<string>showWithTextOnlyStatus</string>
 						</object>
 						<object class="NSArray" key="dict.values">
 							<bool key="EncodedWithXMLCoder">YES</bool>
@@ -485,10 +441,6 @@
 								<string key="name">showWithStatus</string>
 								<string key="candidateClassName">id</string>
 							</object>
-							<object class="IBActionInfo">
-								<string key="name">showWithTextOnlyStatus</string>
-								<string key="candidateClassName">id</string>
-							</object>
 						</object>
 					</object>
 					<object class="IBClassDescriptionSource" key="sourceIdentifier">
@@ -502,7 +454,7 @@
 		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaTouchFramework</string>
 		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDependencyDefaults">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaTouchPlugin.iPhoneOS</string>
-			<real value="1296" key="NS.object.0"/>
+			<real value="1536" key="NS.object.0"/>
 		</object>
 		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDevelopmentDependencies">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaTouchPlugin.InterfaceBuilder3</string>
@@ -510,6 +462,6 @@
 		</object>
 		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
 		<int key="IBDocument.defaultPropertyAccessControl">3</int>
-		<string key="IBCocoaTouchPluginVersion">1498</string>
+		<string key="IBCocoaTouchPluginVersion">1930</string>
 	</data>
 </archive>


### PR DESCRIPTION
[SVProgressHUD showImage:nil status:@"Just some text"] previously caused there to be a blank space where the image should be. Now, in this case the whole hudView is getting smaller, and the label is neatly placed at it's center. --I also added new button to the demo project to test this, and fixed minor timer issues.

![ 2012-12-14 3 38 59](https://f.cloud.github.com/assets/929735/12208/4e9e4580-457e-11e2-8747-3823fd749365.png)

_Update_: Button in the demo project removed.
