### PR TITLE
Add UIAccessibility to showImage:status:duration:

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -443,6 +443,16 @@ CGFloat SVProgressHUDRingThickness = 6;
     [self updatePosition];
     [self.spinnerView stopAnimating];
     
+    if(self.maskType != SVProgressHUDMaskTypeNone) {
+        self.accessibilityLabel = string;
+        self.isAccessibilityElement = YES;
+    } else {
+        self.hudView.accessibilityLabel = string;
+        self.hudView.isAccessibilityElement = YES;
+    }
+
+    UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, string);
+    
     self.fadeOutTimer = [NSTimer timerWithTimeInterval:duration target:self selector:@selector(dismiss) userInfo:nil repeats:NO];
     [[NSRunLoop mainRunLoop] addTimer:self.fadeOutTimer forMode:NSRunLoopCommonModes];
 }


### PR DESCRIPTION
Follow up to @julienp's excellent pull request #101 by adding voice over to `showImage:status:duration:`, mostly so status is spoken when showing success/error HUDs afterwards incase someone needs to know whether their request failed or so on.

The status will cut out if it's too long, but considering the success/error HUDs are only displayed a short time anyway should be keeping the message short anyway. Could listen for `UIAccessibilityAnnouncementDidFinishNotification` and then start the fade out timer, which I can add if needed.
