### PR TITLE
Clamp display duration to a maximum of 5 seconds.

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -632,7 +632,7 @@ CGFloat SVProgressHUDRingThickness = 6;
 #pragma mark - Getters
 
 - (NSTimeInterval)displayDurationForString:(NSString*)string {
-    return (float)string.length*0.06 + 0.3;
+    return MIN((float)string.length*0.06 + 0.3, 5.0);
 }
 
 - (UIButton *)overlayView {


### PR DESCRIPTION
If an exceptionally long display string were used, the HUD could
remain onscreen for quite a long time otherwise.
