### PR TITLE
when keyboard is displayed, move up the gradient overlay center

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -189,7 +189,9 @@ CGFloat SVProgressHUDRingThickness = 6;
             CGGradientRef gradient = CGGradientCreateWithColorComponents(colorSpace, colors, locations, locationsCount);
             CGColorSpaceRelease(colorSpace);
             
-            CGPoint center = CGPointMake(self.bounds.size.width/2, self.bounds.size.height/2);
+            CGFloat freeHeight = self.bounds.size.height - self.visibleKeyboardHeight;
+            
+            CGPoint center = CGPointMake(self.bounds.size.width/2, freeHeight/2);
             float radius = MIN(self.bounds.size.width , self.bounds.size.height) ;
             CGContextDrawRadialGradient (context, gradient, center, 0, center, radius, kCGGradientDrawsAfterEndLocation);
             CGGradientRelease(gradient);


### PR DESCRIPTION
when the "progress" is shown with gradient overlay mask when keyboard is visible,  the progress view is moved up, but not the gradient overlay view. 

below is the original case, 
![snip20130731_1](https://f.cloud.github.com/assets/140474/880455/a6b4a356-f93b-11e2-954b-e3b8e2b6a61a.png)

here is the modified case
![snip20130731_2](https://f.cloud.github.com/assets/140474/880470/eeb50a10-f93b-11e2-991a-45ff8c49672c.png)
