### PR TITLE
Fixes ring layer and customizes it for iOS 7

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -927,7 +927,11 @@ CGFloat SVProgressHUDRingThickness = 6;
     }
 #endif
     
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 70000
+    return [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline];
+#else
     return [UIFont boldSystemFontOfSize:16];
+#endif
 }
 
 - (UIImage *)hudSuccessImage {


### PR DESCRIPTION
• Fixes https://github.com/samvermette/SVProgressHUD/issues/192
• Customizes color and thickness of ring layer for iOS 7
• Foreground color used is the UIWindow's `tintColor`, so it will match other buttons throughout the app
![screen shot 2013-09-13 at 9 30 35 am](https://f.cloud.github.com/assets/789577/1138984/0938d344-1c82-11e3-868e-e2c34527e7ec.png)

• Uses `preferredFontForTextStyle:` as default font on iOS 7
