### PR TITLE
Customizable UIWindowLevel.

### DIFF
--- a/SVProgressHUD/SVProgressHUD.h
+++ b/SVProgressHUD/SVProgressHUD.h
@@ -40,6 +40,8 @@ typedef NSUInteger SVProgressHUDMaskType;
 @property (readwrite, nonatomic, retain) UIImage *hudErrorImage NS_AVAILABLE_IOS(5_0) UI_APPEARANCE_SELECTOR;
 #endif
 
+@property (nonatomic) UIWindowLevel windowLevel;
+
 + (void)setOffsetFromCenter:(UIOffset)offset;
 + (void)resetOffsetFromCenter;
 
@@ -53,6 +55,7 @@ typedef NSUInteger SVProgressHUDMaskType;
 + (void)showProgress:(float)progress status:(NSString*)status maskType:(SVProgressHUDMaskType)maskType;
 
 + (void)setStatus:(NSString*)string; // change the HUD loading status while it's showing
++ (void)setWindowLevel:(UIWindowLevel)windowLevel;
 
 // stops the activity indicator, shows a glyph + status, and dismisses HUD 1s later
 + (void)showSuccessWithStatus:(NSString*)string;

--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -99,13 +99,20 @@ CGFloat SVProgressHUDRingThickness = 6;
 + (SVProgressHUD*)sharedView {
     static dispatch_once_t once;
     static SVProgressHUD *sharedView;
-    dispatch_once(&once, ^ { sharedView = [[self alloc] initWithFrame:[[UIScreen mainScreen] bounds]]; });
+    dispatch_once(&once, ^ {
+        sharedView = [[self alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
+        sharedView.windowLevel = UIWindowLevelNormal;
+    });
     return sharedView;
 }
 
 
 + (void)setStatus:(NSString *)string {
 	[[self sharedView] setStatus:string];
+}
+
++ (void)setWindowLevel:(UIWindowLevel)windowLevel {
+    [[self sharedView] setWindowLevel:windowLevel];
 }
 
 #pragma mark - Show Methods
@@ -448,7 +455,7 @@ CGFloat SVProgressHUDRingThickness = 6;
         NSEnumerator *frontToBackWindows = [[[UIApplication sharedApplication]windows]reverseObjectEnumerator];
         
         for (UIWindow *window in frontToBackWindows)
-            if (window.windowLevel == UIWindowLevelNormal) {
+            if (window.windowLevel == self.windowLevel) {
                 [window addSubview:self.overlayView];
                 break;
             }


### PR DESCRIPTION
I've found cases where I do want the HUD to be on a window with a different level than `UIWindowLevelNormal `, so I thought it might be good to be able to set it as a client, but leaving the old default as is.