### PR TITLE
Converts float types to CGFloat

### DIFF
--- a/SVProgressHUD.xcodeproj/project.pbxproj
+++ b/SVProgressHUD.xcodeproj/project.pbxproj
@@ -197,6 +197,7 @@
 		65F0220B15C857EF0030BBEF /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				DSTROOT = /tmp/SVProgressHUD.dst;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "SVProgressHUD/SVProgressHUD-Prefix.pch";
@@ -209,6 +210,7 @@
 		65F0220C15C857EF0030BBEF /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				DSTROOT = /tmp/SVProgressHUD.dst;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "SVProgressHUD/SVProgressHUD-Prefix.pch";

--- a/SVProgressHUD/SVProgressHUD.h
+++ b/SVProgressHUD/SVProgressHUD.h
@@ -48,9 +48,9 @@ typedef NSUInteger SVProgressHUDMaskType;
 + (void)showWithStatus:(NSString*)status;
 + (void)showWithStatus:(NSString*)status maskType:(SVProgressHUDMaskType)maskType;
 
-+ (void)showProgress:(float)progress;
-+ (void)showProgress:(float)progress status:(NSString*)status;
-+ (void)showProgress:(float)progress status:(NSString*)status maskType:(SVProgressHUDMaskType)maskType;
++ (void)showProgress:(CGFloat)progress;
++ (void)showProgress:(CGFloat)progress status:(NSString*)status;
++ (void)showProgress:(CGFloat)progress status:(NSString*)status maskType:(SVProgressHUDMaskType)maskType;
 
 + (void)setStatus:(NSString*)string; // change the HUD loading status while it's showing
 

--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -51,7 +51,7 @@ static const CGFloat SVProgressHUDRingThickness = 6;
 @property (nonatomic, readonly) CGFloat visibleKeyboardHeight;
 @property (nonatomic, assign) UIOffset offsetFromCenter;
 
-- (void)showProgress:(float)progress
+- (void)showProgress:(CGFloat)progress
               status:(NSString*)string
             maskType:(SVProgressHUDMaskType)hudMaskType;
 
@@ -127,15 +127,15 @@ static const CGFloat SVProgressHUDRingThickness = 6;
     [[self sharedView] showProgress:-1 status:status maskType:maskType];
 }
 
-+ (void)showProgress:(float)progress {
++ (void)showProgress:(CGFloat)progress {
     [[self sharedView] showProgress:progress status:nil maskType:SVProgressHUDMaskTypeNone];
 }
 
-+ (void)showProgress:(float)progress status:(NSString *)status {
++ (void)showProgress:(CGFloat)progress status:(NSString *)status {
     [[self sharedView] showProgress:progress status:status maskType:SVProgressHUDMaskTypeNone];
 }
 
-+ (void)showProgress:(float)progress status:(NSString *)status maskType:(SVProgressHUDMaskType)maskType {
++ (void)showProgress:(CGFloat)progress status:(NSString *)status maskType:(SVProgressHUDMaskType)maskType {
     [[self sharedView] showProgress:progress status:status maskType:maskType];
 }
 
@@ -219,7 +219,7 @@ static const CGFloat SVProgressHUDRingThickness = 6;
             CGFloat freeHeight = self.bounds.size.height - self.visibleKeyboardHeight;
             
             CGPoint center = CGPointMake(self.bounds.size.width/2, freeHeight/2);
-            float radius = MIN(self.bounds.size.width , self.bounds.size.height) ;
+            CGFloat radius = MIN(self.bounds.size.width , self.bounds.size.height) ;
             CGContextDrawRadialGradient (context, gradient, center, 0, center, radius, kCGGradientDrawsAfterEndLocation);
             CGGradientRelease(gradient);
             
@@ -377,7 +377,7 @@ static const CGFloat SVProgressHUDRingThickness = 6;
     CGRect statusBarFrame = [UIApplication sharedApplication].statusBarFrame;
     
     if(UIInterfaceOrientationIsLandscape(orientation)) {
-        float temp = orientationFrame.size.width;
+        CGFloat temp = orientationFrame.size.width;
         orientationFrame.size.width = orientationFrame.size.height;
         orientationFrame.size.height = temp;
         
@@ -443,7 +443,7 @@ static const CGFloat SVProgressHUDRingThickness = 6;
 
 #pragma mark - Master show/dismiss methods
 
-- (void)showProgress:(float)progress status:(NSString*)string maskType:(SVProgressHUDMaskType)hudMaskType {
+- (void)showProgress:(CGFloat)progress status:(NSString*)string maskType:(SVProgressHUDMaskType)hudMaskType {
     
     if(!self.overlayView.superview){
         NSEnumerator *frontToBackWindows = [[[UIApplication sharedApplication]windows]reverseObjectEnumerator];


### PR DESCRIPTION
By having the private declaration of the showProgress methods as "float" and the public declaration of the showProgress methods as CGFloat, a compile targeting a 64bit architecture was failing. The progress property is a CGFloat, so I thought it made sense to convert the parameters to CGFloat.

I've also updated methods that are requesting CGFloat values but casting them to a float. 

These are issues because on a 64bit architecture, a CGFloat is a double, and not a float.
