### PR TITLE
Fixed build errors when target version <7.0

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -745,6 +745,7 @@ static const CGFloat SVProgressHUDRingThickness = 6;
         _hudView.autoresizingMask = (UIViewAutoresizingFlexibleBottomMargin | UIViewAutoresizingFlexibleTopMargin |
                                      UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleLeftMargin);
         
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 70000
         UIInterpolatingMotionEffect *effectX = [[UIInterpolatingMotionEffect alloc] initWithKeyPath: @"center.x" type: UIInterpolatingMotionEffectTypeTiltAlongHorizontalAxis];
         effectX.minimumRelativeValue = @(-SVProgressHUDParallaxDepthPoints);
         effectX.maximumRelativeValue = @(SVProgressHUDParallaxDepthPoints);
@@ -755,7 +756,7 @@ static const CGFloat SVProgressHUDRingThickness = 6;
         
         [_hudView addMotionEffect: effectX];
         [_hudView addMotionEffect: effectY];
-        
+#endif
         [self addSubview:_hudView];
     }
     return _hudView;


### PR DESCRIPTION
Use iOS 7 features only, if min target is 7.0 or higher.
