### PR TITLE
Fixed problem calling dismiss and then show

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -556,6 +556,10 @@ static const CGFloat SVProgressHUDRingThickness = 6;
                                                       userInfo:userInfo];
     
     self.activityCount = 0;
+       
+    //Update alpha because it is used to detect whether the HUD is visible.
+    self.alpha -= 0.01;
+
     [UIView animateWithDuration:0.15
                           delay:0
                         options:UIViewAnimationCurveEaseIn | UIViewAnimationOptionAllowUserInteraction


### PR DESCRIPTION
If you do a `[SVProgressHUD dismiss];` and then a `[SVProgressHUD show];` the `show` is ignored because the flag to detect if the show should do something is the `alpha` color, but it is not modified yet as it is part of a `UIAnimation`. By reducing the alpha right away we can fix the issue without visible impact.
