### PR TITLE
Fix showWithStatus not working after quick hide/show calls when isClear is true

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -519,7 +519,7 @@ static const CGFloat SVProgressHUDParallaxDepthPoints = 10;
     self.overlayView.backgroundColor = [UIColor clearColor];
     [self positionHUD:nil];
     
-    if(self.alpha != 1) {
+    if(self.alpha != 1 || self.hudView.alpha != 1) {
         NSDictionary *userInfo = [self notificationUserInfo];
         [[NSNotificationCenter defaultCenter] postNotificationName:SVProgressHUDWillAppearNotification
                                                             object:nil


### PR DESCRIPTION
This commit resolves the issue outlined and reproduced in https://github.com/samvermette/SVProgressHUD/issues/251

Essentially, whenever the HUD `isClear` evaluates to true, `-showProgress:status:maskType:` sets `self.hudView.alpha = 1`, but is blocked by the check `if(self.alpha != 1)`. The check should instead be `if(self.alpha != 1 || self.hudView.alpha != 1)`

[Line 608](https://github.com/samvermette/SVProgressHUD/blob/master/SVProgressHUD/SVProgressHUD.m#L608) shows a similar check being performed in `-dismiss`
