### PR TITLE
Init animationDuration to 0.0 to avoid compile warning

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -375,7 +375,7 @@ static const CGFloat SVProgressHUDParallaxDepthPoints = 10;
 - (void)positionHUD:(NSNotification*)notification {
     
     CGFloat keyboardHeight;
-    double animationDuration;
+    double animationDuration = 0.0;
     
     UIInterfaceOrientation orientation = [[UIApplication sharedApplication] statusBarOrientation];
     


### PR DESCRIPTION
To avoid this warning:
SVProgressHUD.m:443:37: Variable 'animationDuration' may be
uninitialized when used here
