### PR TITLE
Fixed an issue when the top window is hidden because this is not the root

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -507,11 +507,13 @@ static const CGFloat SVProgressHUDParallaxDepthPoints = 10;
 
 - (void)showProgress:(float)progress status:(NSString*)string maskType:(SVProgressHUDMaskType)hudMaskType {
     
-    if(!self.overlayView.superview){
-        NSEnumerator *frontToBackWindows = [[[UIApplication sharedApplication]windows]reverseObjectEnumerator];
+    if( !self.overlayView.superview || self.overlayView.superview.hidden ){
+        [self.overlayView removeFromSuperview];
+        
+        NSEnumerator *frontToBackWindows = [[[UIApplication sharedApplication] windows] reverseObjectEnumerator];
         
         for (UIWindow *window in frontToBackWindows)
-            if (window.windowLevel == UIWindowLevelNormal) {
+            if (window.windowLevel == UIWindowLevelNormal && !window.hidden) {
                 [window addSubview:self.overlayView];
                 break;
             }


### PR DESCRIPTION
If you use some components like https://github.com/ipodishima/RZNotificationView-1/tree/ios7-dev, there are placed on a window which becomes not visible after showing a notification