### PR TITLE
Fix typo in LICENSE.txt ('ressources' => 'resources')

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -21,6 +21,6 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
-A different license may apply to other ressources included in this package, 
+A different license may apply to other resources included in this package, 
 including Joseph Wain's Glyphish Icons. Please consult their 
 respective headers for the terms of their individual licenses.


### PR DESCRIPTION
Thanks for the great pod! :octocat: 
