### PR TITLE
[*] SVProgressHUD - fixed. Now HUD show only on keyWindow

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -477,7 +477,7 @@ static const CGFloat SVProgressHUDParallaxDepthPoints = 10;
         NSEnumerator *frontToBackWindows = [[[UIApplication sharedApplication]windows]reverseObjectEnumerator];
         
         for (UIWindow *window in frontToBackWindows)
-            if (window.windowLevel == UIWindowLevelNormal) {
+            if (window.windowLevel == UIWindowLevelNormal && [window isKeyWindow]) {
                 [window addSubview:self.overlayView];
                 break;
             }


### PR DESCRIPTION
This fix allows to show hud on keyWindow.
Some apps may contain more than one key window.