### PR TITLE
Adds ability to set mask type of shared view

### DIFF
--- a/SVProgressHUD/SVProgressHUD.h
+++ b/SVProgressHUD/SVProgressHUD.h
@@ -50,6 +50,7 @@ typedef NSUInteger SVProgressHUDMaskType;
 + (void)showProgress:(float)progress status:(NSString*)status maskType:(SVProgressHUDMaskType)maskType;
 
 + (void)setStatus:(NSString*)string; // change the HUD loading status while it's showing
++ (void)setMaskType:(SVProgressHUDMaskType)maskType;
 
 // stops the activity indicator, shows a glyph + status, and dismisses HUD 1s later
 + (void)showSuccessWithStatus:(NSString*)string;

--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -89,6 +89,10 @@ static const CGFloat SVProgressHUDParallaxDepthPoints = 10;
 	[[self sharedView] setStatus:string];
 }
 
++ (void)setMaskType:(SVProgressHUDMaskType)maskType {
+    [self sharedView].maskType = maskType;
+}
+
 + (void)setBackgroundColor:(UIColor *)color {
     [self sharedView].hudView.backgroundColor = color;
     SVProgressHUDBackgroundColor = color;


### PR DESCRIPTION
Using `showSuccessWithStatus` doesn't support different mask types, freezing the app whenever the user succeeds in doing anything.
