### PR TITLE
Fixed issue where a changed foreground color wasn't being applied to the status label after the progress HUD was already shown

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -819,10 +819,11 @@ static const CGFloat SVProgressHUDParallaxDepthPoints = 10;
 		_stringLabel.adjustsFontSizeToFitWidth = YES;
         _stringLabel.textAlignment = NSTextAlignmentCenter;
 		_stringLabel.baselineAdjustment = UIBaselineAdjustmentAlignCenters;
-		_stringLabel.textColor = SVProgressHUDForegroundColor;
 		_stringLabel.font = SVProgressHUDFont;
         _stringLabel.numberOfLines = 0;
     }
+    
+    _stringLabel.textColor = SVProgressHUDForegroundColor;
     
     if(!_stringLabel.superview)
         [self.hudView addSubview:_stringLabel];


### PR DESCRIPTION
Refer here for an issue that was logged which addresses the problem: https://github.com/TransitApp/SVProgressHUD/issues/324
