### PR TITLE
Fix for deprecated sizeWithFont: method in iOS 8 SDK

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -282,8 +282,13 @@ static const CGFloat SVProgressHUDParallaxDepthPoints = 10;
                                          attributes:@{NSFontAttributeName: self.stringLabel.font}
                                             context:NULL];
         } else {
-          CGSize stringSize = [string sizeWithFont:self.stringLabel.font constrainedToSize:CGSizeMake(200, 300)];
-          stringRect = CGRectMake(0.0f, 0.0f, stringSize.width, stringSize.height);
+            CGSize stringSize;
+            #ifdef __IPHONE_8_0
+                stringSize = [string sizeWithAttributes:@{NSFontAttributeName:[UIFont fontWithName:self.stringLabel.font.fontName size:self.stringLabel.font.pointSize]}];
+            #else
+                stringSize = [string sizeWithFont:self.stringLabel.font constrainedToSize:CGSizeMake(200, 300)];
+            #endif
+            stringRect = CGRectMake(0.0f, 0.0f, stringSize.width, stringSize.height);
         }
         stringWidth = stringRect.size.width;
         stringHeight = ceil(stringRect.size.height);


### PR DESCRIPTION
This commit contains a replacement for the deprecated method `sizeWithFont:` that yielded a warning in Xcode 6 / iOS 8 SDK
