### PR TITLE
[PATCH] Fix: progress HUD appearing on external display

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -509,9 +509,10 @@ static const CGFloat SVProgressHUDParallaxDepthPoints = 10;
     
     if(!self.overlayView.superview){
         NSEnumerator *frontToBackWindows = [[[UIApplication sharedApplication]windows]reverseObjectEnumerator];
+        UIScreen *mainScreen = [UIScreen mainScreen];
         
         for (UIWindow *window in frontToBackWindows)
-            if (window.windowLevel == UIWindowLevelNormal) {
+            if (window.screen == mainScreen && window.windowLevel == UIWindowLevelNormal) {
                 [window addSubview:self.overlayView];
                 break;
             }


### PR DESCRIPTION
If an external display is connected and contains UIWindow, SVProgressHUD would previously pick it instead of the window on the main screen.

The proposed fix changes `- [SVProgressHud showProgress:status:mask:]` to only consider windows on `[UIScreen mainScreen]`.
