### PR TITLE
Remove iOS version check due to use of boundingRectWithSize

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -276,23 +276,11 @@ static const CGFloat SVProgressHUDParallaxDepthPoints = 10;
     if(string) {
         CGSize constraintSize = CGSizeMake(200, 300);
         CGRect stringRect;
-        #if __IPHONE_OS_VERSION_MIN_REQUIRED >= 70000
-            stringRect = [string boundingRectWithSize:constraintSize
-                                                  options:(NSStringDrawingUsesFontLeading|NSStringDrawingTruncatesLastVisibleLine|NSStringDrawingUsesLineFragmentOrigin)
-                                               attributes:@{NSFontAttributeName: self.stringLabel.font}
-                                                  context:NULL];
-        #else
-            if ([string respondsToSelector:@selector(boundingRectWithSize:options:attributes:context:)]) {
-                stringRect = [string boundingRectWithSize:constraintSize
-                                                  options:(NSStringDrawingUsesFontLeading|NSStringDrawingTruncatesLastVisibleLine|NSStringDrawingUsesLineFragmentOrigin)
-                                               attributes:@{NSFontAttributeName: self.stringLabel.font}
-                                                  context:NULL];
-            else {
-                CGSize stringSize;
-                stringSize = [string sizeWithFont:self.stringLabel.font constrainedToSize:CGSizeMake(200, 300)];
-                stringRect = CGRectMake(0.0f, 0.0f, stringSize.width, stringSize.height);
-            }
-        #endif
+
+        stringRect = [string boundingRectWithSize:constraintSize
+                                              options:(NSStringDrawingUsesFontLeading|NSStringDrawingTruncatesLastVisibleLine|NSStringDrawingUsesLineFragmentOrigin)
+                                           attributes:@{NSFontAttributeName: self.stringLabel.font}
+                                              context:NULL];
         
         stringWidth = stringRect.size.width;
         stringHeight = ceil(stringRect.size.height);


### PR DESCRIPTION
As discussed in https://github.com/TransitApp/SVProgressHUD/pull/335

Actually the `boundingRectWithSize` is supported from iOS 7 and above, and I thought it was iOS 8 and above. So iOS 7 support is not an issue.
