### PR TITLE
Allow changeability of string label once initiated

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -829,13 +829,14 @@ static const CGFloat SVProgressHUDParallaxDepthPoints = 10;
 		_stringLabel.adjustsFontSizeToFitWidth = YES;
         _stringLabel.textAlignment = NSTextAlignmentCenter;
 		_stringLabel.baselineAdjustment = UIBaselineAdjustmentAlignCenters;
-		_stringLabel.textColor = SVProgressHUDForegroundColor;
-		_stringLabel.font = SVProgressHUDFont;
         _stringLabel.numberOfLines = 0;
     }
     
     if(!_stringLabel.superview)
         [self.hudView addSubview:_stringLabel];
+
+    _stringLabel.textColor = SVProgressHUDForegroundColor;
+    _stringLabel.font = SVProgressHUDFont;
     
     return _stringLabel;
 }


### PR DESCRIPTION
-allowing the label's text colour and font to be changed, otherwise it will retain the color/font values used the very first time only when it was initiated
-unsure why there was no changeability before, if this was against original intentions please comment and let me know :)
