### PR TITLE
Add other enum values to switch.

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -244,6 +244,10 @@ static const CGFloat SVProgressHUDParallaxDepthPoints = 10;
             
             break;
         }
+
+		case SVProgressHUDMaskTypeClear:
+		case SVProgressHUDMaskTypeNone:
+			break;
     }
 }
 


### PR DESCRIPTION
This allows SVProgressHUD to be built with the compiler warning -Wswitch.
