### PR TITLE
Fixed semantic warning for unhandled cases in SVProgressHUDMaskType switch statement

### DIFF
--- a/SVProgressHUD.podspec
+++ b/SVProgressHUD.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'SVProgressHUD'
-  s.version  = '1.0'
+  s.version  = '1.1'
   s.platform = :ios
   s.license  = 'MIT'
   s.summary  = 'A clean and lightweight progress HUD for your iOS app.'

--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -255,6 +255,8 @@ static const CGFloat SVProgressHUDParallaxDepthPoints = 10;
             
             break;
         }
+	default:
+	    break;
     }
 }
 


### PR DESCRIPTION
Once you merge this, would you also be willing to create a new 1.1 release tag of SVProgressHUD, then push the pod to the CocoaPod spec repo? That will enable all the developers using your library through CocoaPods to get all the great fixed/enhancements that have gone in over the last +year.

Thanks!
