### PR TITLE
Disable content view of view controller

### DIFF
--- a/SVProgressHUD/SVProgressHUD.h
+++ b/SVProgressHUD/SVProgressHUD.h
@@ -73,6 +73,8 @@ typedef NS_ENUM(NSUInteger, SVProgressHUDMaskType) {
 + (void)popActivity; // decrease activity count, if activity count == 0 the HUD is dismissed
 + (void)dismiss;
 
++ (void)disableParent:(UIView *) contentView;
+
 + (BOOL)isVisible;
 
 @end

--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -228,7 +228,6 @@ static const CGFloat SVProgressHUDUndefinedProgress = -1;
 
 + (void)dismiss {
     if ([self isVisible]) {
-        [[self sharedView].parent setUserInteractionEnabled:YES];
         [[self sharedView] dismiss];
     }
 }
@@ -749,6 +748,9 @@ static const CGFloat SVProgressHUDUndefinedProgress = -1;
 }
 
 - (void)dismiss {
+    if(self.parent != nil){
+        [self.parent setUserInteractionEnabled:YES];
+    }
     NSDictionary *userInfo = [self notificationUserInfo];
     [[NSNotificationCenter defaultCenter] postNotificationName:SVProgressHUDWillDisappearNotification
                                                         object:nil

--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -46,6 +46,7 @@ static const CGFloat SVProgressHUDUndefinedProgress = -1;
 
 @property (nonatomic, strong) UIControl *overlayView;
 @property (nonatomic, strong) UIView *hudView;
+@property (nonatomic, strong) UIView *parent;
 @property (nonatomic, strong) UILabel *stringLabel;
 @property (nonatomic, strong) UIImageView *imageView;
 @property (nonatomic, strong) SVIndefiniteAnimatedView *indefiniteAnimatedView;
@@ -227,8 +228,16 @@ static const CGFloat SVProgressHUDUndefinedProgress = -1;
 
 + (void)dismiss {
     if ([self isVisible]) {
+        [[self sharedView].parent setUserInteractionEnabled:YES];
         [[self sharedView] dismiss];
     }
+}
+
+#pragma mark - disable parent
+
++ (void)disableParent:(UIView *) contentView{
+    [self sharedView].parent = contentView;
+    [[self sharedView].parent setUserInteractionEnabled:NO];
 }
 
 


### PR DESCRIPTION
This is a small patch containing a new function disableParent: which disables the content view of the view controller the SVProgressHUD is currently laying on. This prevents touch actions going to the underlaying view controller. 