### PR TITLE
added SVProgressHUDUpdateViewNotification

### DIFF
--- a/SVProgressHUD/SVProgressHUD.h
+++ b/SVProgressHUD/SVProgressHUD.h
@@ -20,8 +20,10 @@ extern NSString * const SVProgressHUDWillDisappearNotification;
 extern NSString * const SVProgressHUDDidDisappearNotification;
 extern NSString * const SVProgressHUDWillAppearNotification;
 extern NSString * const SVProgressHUDDidAppearNotification;
+extern NSString * const SVProgressHUDUpdateViewNotification;
 
 extern NSString * const SVProgressHUDStatusUserInfoKey;
+
 
 typedef NS_ENUM(NSInteger, SVProgressHUDStyle) {
     SVProgressHUDStyleLight,        // default style, white HUD with black text, HUD background will be blurred on iOS 8 and above

--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -19,6 +19,7 @@ NSString * const SVProgressHUDWillDisappearNotification = @"SVProgressHUDWillDis
 NSString * const SVProgressHUDDidDisappearNotification = @"SVProgressHUDDidDisappearNotification";
 NSString * const SVProgressHUDWillAppearNotification = @"SVProgressHUDWillAppearNotification";
 NSString * const SVProgressHUDDidAppearNotification = @"SVProgressHUDDidAppearNotification";
+NSString * const SVProgressHUDUpdateViewNotification = @"SVProgressHUDUpdateViewNotification";
 
 NSString * const SVProgressHUDStatusUserInfoKey = @"SVProgressHUDStatusUserInfoKey";
 
@@ -586,6 +587,12 @@ static const CGFloat SVProgressHUDUndefinedProgress = -1;
                                                  name:UIApplicationDidChangeStatusBarOrientationNotification
                                                object:nil];
 #endif
+
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(positionHUD:)
+                                                 name:SVProgressHUDUpdateViewNotification
+                                               object:nil];
+
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(positionHUD:)
                                                  name:UIApplicationDidBecomeActiveNotification


### PR DESCRIPTION
to force ProgressHUD refresh view and avoid app confusing firing other notifications
required for cases to manipulate or hide progress hud view, but keep it on the screen
