### PR TITLE
dismiss duration 0.15 maybe lead to a bug

### DIFF
--- a/SVProgressHUD/SVProgressHUD.h
+++ b/SVProgressHUD/SVProgressHUD.h
@@ -113,6 +113,7 @@ typedef NS_ENUM(NSUInteger, SVProgressHUDAnimationType) {
 + (void)popActivity; // decrease activity count, if activity count == 0 the HUD is dismissed
 + (void)dismiss;
 + (void)dismissWithDelay:(NSTimeInterval)delay; // delayes the dismissal
++ (void)dismissWithDuration:(NSTimeInterval)duration delay:(NSTimeInterval)delay; // duration and delayes the dismissal
 
 + (BOOL)isVisible;
 

--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -67,7 +67,7 @@ static const CGFloat SVProgressHUDUndefinedProgress = -1;
 - (void)showProgress:(float)progress status:(NSString*)string;
 - (void)showImage:(UIImage*)image status:(NSString*)status duration:(NSTimeInterval)duration;
 
-- (void)dismissWithDelay:(NSTimeInterval)delay;
+- (void)dismissWithDuration:(NSTimeInterval)duration delay:(NSTimeInterval)delay;
 - (void)dismiss;
 
 - (UIActivityIndicatorView *)createActivityIndicatorView;
@@ -281,10 +281,14 @@ static const CGFloat SVProgressHUDUndefinedProgress = -1;
     }
 }
 
-+ (void)dismissWithDelay:(NSTimeInterval)delay{
++ (void)dismissWithDuration:(NSTimeInterval)duration delay:(NSTimeInterval)delay{
     if([self isVisible]){
-        [[self sharedView] dismissWithDelay:delay];
+        [[self sharedView] dismissWithDuration:duration delay:delay];
     }
+}
+
++ (void)dismissWithDelay:(NSTimeInterval)delay{
+    [SVProgressHUD dismissWithDuration:0.15 delay:delay];
 }
 
 + (void)dismiss{
@@ -925,7 +929,7 @@ static const CGFloat SVProgressHUDUndefinedProgress = -1;
     [[NSRunLoop mainRunLoop] addTimer:self.fadeOutTimer forMode:NSRunLoopCommonModes];
 }
 
-- (void)dismissWithDelay:(NSTimeInterval)delay{
+- (void)dismissWithDuration:(NSTimeInterval)duration delay:(NSTimeInterval)delay{
     NSDictionary *userInfo = [self notificationUserInfo];
     [[NSNotificationCenter defaultCenter] postNotificationName:SVProgressHUDWillDisappearNotification
                                                         object:nil
@@ -933,7 +937,7 @@ static const CGFloat SVProgressHUDUndefinedProgress = -1;
     
     self.activityCount = 0;
     __weak SVProgressHUD *weakSelf = self;
-    [UIView animateWithDuration:0.15
+    [UIView animateWithDuration:duration
                           delay:delay
                         options:(UIViewAnimationOptions) (UIViewAnimationCurveEaseIn | UIViewAnimationOptionAllowUserInteraction)
                      animations:^{
@@ -988,7 +992,7 @@ static const CGFloat SVProgressHUDUndefinedProgress = -1;
 
 - (void)dismiss
 {
-    [self dismissWithDelay:0];
+    [self dismissWithDuration:0 delay:0];
 }
 
 

--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -937,57 +937,70 @@ static const CGFloat SVProgressHUDUndefinedProgress = -1;
     
     self.activityCount = 0;
     __weak SVProgressHUD *weakSelf = self;
-    [UIView animateWithDuration:duration
-                          delay:delay
-                        options:(UIViewAnimationOptions) (UIViewAnimationCurveEaseIn | UIViewAnimationOptionAllowUserInteraction)
-                     animations:^{
-                         __strong SVProgressHUD *strongSelf = weakSelf;
-                         if(strongSelf){
-                             strongSelf.hudView.transform = CGAffineTransformScale(self.hudView.transform, 0.8f, 0.8f);
-                             if(strongSelf.isClear){ // handle iOS 7 UIToolbar not answer well to hierarchy opacity change
-                                 strongSelf.hudView.alpha = 0.0f;
-                             } else{
-                                 strongSelf.alpha = 0.0f;
-                             }
-                         }
-                     }
-                     completion:^(BOOL finished){
-                         __strong SVProgressHUD *strongSelf = weakSelf;
-                         if(strongSelf){
-                             if(strongSelf.alpha == 0.0f || strongSelf.hudView.alpha == 0.0f){
-                                 strongSelf.alpha = 0.0f;
-                                 strongSelf.hudView.alpha = 0.0f;
-                                 
-                                 [[NSNotificationCenter defaultCenter] removeObserver:strongSelf];
-                                 [strongSelf cancelRingLayerAnimation];
-                                 [_hudView removeFromSuperview];
-                                 _hudView = nil;
-                                 
-                                 [_overlayView removeFromSuperview];
-                                 _overlayView = nil;
-                                 
-                                 [_indefiniteAnimatedView removeFromSuperview];
-                                 _indefiniteAnimatedView = nil;
-                                 
-                                 UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, nil);
-                                 
-                                 [[NSNotificationCenter defaultCenter] postNotificationName:SVProgressHUDDidDisappearNotification
-                                                                                     object:nil
-                                                                                   userInfo:userInfo];
-                                 
-                                 // Tell the rootViewController to update the StatusBar appearance
+    void (^animationBlock) (void) = ^{
+        __strong SVProgressHUD *strongSelf = weakSelf;
+        if(strongSelf){
+            strongSelf.hudView.transform = CGAffineTransformScale(self.hudView.transform, 0.8f, 0.8f);
+            if(strongSelf.isClear){ // handle iOS 7 UIToolbar not answer well to hierarchy opacity change
+                strongSelf.hudView.alpha = 0.0f;
+            } else{
+                strongSelf.alpha = 0.0f;
+            }
+        }
+    };
+    void (^completionBlock) (void) = ^{
+        __strong SVProgressHUD *strongSelf = weakSelf;
+        if(strongSelf){
+            if(strongSelf.alpha == 0.0f || strongSelf.hudView.alpha == 0.0f){
+                strongSelf.alpha = 0.0f;
+                strongSelf.hudView.alpha = 0.0f;
+                
+                [[NSNotificationCenter defaultCenter] removeObserver:strongSelf];
+                [strongSelf cancelRingLayerAnimation];
+                [_hudView removeFromSuperview];
+                _hudView = nil;
+                
+                [_overlayView removeFromSuperview];
+                _overlayView = nil;
+                
+                [_indefiniteAnimatedView removeFromSuperview];
+                _indefiniteAnimatedView = nil;
+                
+                UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, nil);
+                
+                [[NSNotificationCenter defaultCenter] postNotificationName:SVProgressHUDDidDisappearNotification
+                                                                    object:nil
+                                                                  userInfo:userInfo];
+                
+                // Tell the rootViewController to update the StatusBar appearance
 #if !defined(SV_APP_EXTENSIONS) && TARGET_OS_IOS
-                                 UIViewController *rootController = [[UIApplication sharedApplication] keyWindow].rootViewController;
-                                 if([rootController respondsToSelector:@selector(setNeedsStatusBarAppearanceUpdate)]){
-                                     [rootController setNeedsStatusBarAppearanceUpdate];
-                                 }
+                UIViewController *rootController = [[UIApplication sharedApplication] keyWindow].rootViewController;
+                if([rootController respondsToSelector:@selector(setNeedsStatusBarAppearanceUpdate)]){
+                    [rootController setNeedsStatusBarAppearanceUpdate];
+                }
 #endif
-                                 // uncomment to make sure UIWindow is gone from app.windows
-                                 //NSLog(@"%@", [UIApplication sharedApplication].windows);
-                                 //NSLog(@"keyWindow = %@", [[[UIApplication sharedApplication] delegate] window]);
-                             }
+                // uncomment to make sure UIWindow is gone from app.windows
+                //NSLog(@"%@", [UIApplication sharedApplication].windows);
+                //NSLog(@"keyWindow = %@", [[[UIApplication sharedApplication] delegate] window]);
+            }
+        }
+    };
+    
+    if (duration == 0) {
+        animationBlock();
+        completionBlock();
+    }
+    else {
+        [UIView animateWithDuration:duration
+                              delay:delay
+                            options:(UIViewAnimationOptions) (UIViewAnimationCurveEaseIn | UIViewAnimationOptionAllowUserInteraction)
+                         animations:^{
+                             animationBlock();
                          }
-                     }];
+                         completion:^(BOOL finished){
+                             completionBlock();
+                         }];
+    }
 }
 
 - (void)dismiss


### PR DESCRIPTION
1. [SVProgress show…] // self.overlayView.superview is window1
2. [SVProgress dismiss] // it dismiss progress duration 0.15s to
completion, completion called by async.
3. new a window2 immediately。
4. [SVProgress show] // it is a bug, it is show in window1 rather than
window2. but we often like it show in window.

1.I change dimiss method interface 
 `- (void)dismissWithDelay:(NSTimeInterval)delay`
 to
 `- (void)dismissWithDuration:(NSTimeInterval)duration delay:(NSTimeInterval)delay`,
 and add a class method
 `+ (void)dismissWithDuration:(NSTimeInterval)duration delay:(NSTimeInterval)delay`
2. I change dimiss method implemention
if duration == 0，sync call `animationBlock` and `completionBlock`,
 if use `animateWithDuration:0
                          delay:delay
                        options:…`
the completion will call async。it maybe lead to a bug