### PR TITLE
Move changelog to project repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+## Version 2.0-beta9 (soon)
+* Fixed: `:head` not available anymore in Cocoapods #552
+
+
+## Version 2.0-beta8
+* Fixed: Progress HUD intersects with default spinner #551
+* Fixed: Update Carthage installation guides #550
+* Fixed: Outdated licenses
+
+## Version 2.0-beta6
+* Fixed: Added success image back, was removed to test a bugfix
+
+## Version 2.0-beta5
+* Fixed: HUD not showing on root view controller in `viewDidLoad` and `viewWillAppear` #536
+* Fixed: When showing with `nil` image, layout wrong size #548
+
+## Version 2.0-beta4
+* Fixed: Notification typo #545
+* Fixed: Remove duplicate declarations
+
+## Version 2.0-beta3
+* Fixed: Cocoapods bundle problem #542
+
+## Version 2.0-beta2
+* Fixed: Dismiss duration 0.15 maybe lead to a bug #529
+* Fixed: Don't apply blur for custom style #508
+* Fixed: No supported interface orientation in real time #490
+
+## Version 2.0-beta
+* New: Support for tvOS 
+* New: UIAppearance support
+* New: Moved Repo to an own organisation
+* Fixed: Many things ... 


### PR DESCRIPTION
The project changelog is currently available on the repo GitHub wiki. I think it would be nicer to keep it as a dedicated file inside the repo itself

### Pros
- easier to find (visible from the main page)
- no longer relies on GitHub having a wiki
- displays on CocoaPods.org (example: [AFNetworking](https://cocoapods.org/pods/AFNetworking))

### Cons
- one more file in the repo
