### PR TITLE
Add support for dimming color and fade customizations

### DIFF
--- a/SVProgressHUD/SVProgressHUD.h
+++ b/SVProgressHUD/SVProgressHUD.h
@@ -48,21 +48,25 @@ typedef NS_ENUM(NSUInteger, SVProgressHUDAnimationType) {
 @property (assign, nonatomic) SVProgressHUDStyle defaultStyle UI_APPEARANCE_SELECTOR;                   // default is SVProgressHUDStyleLight
 @property (assign, nonatomic) SVProgressHUDMaskType defaultMaskType UI_APPEARANCE_SELECTOR;             // default is SVProgressHUDMaskTypeNone
 @property (assign, nonatomic) SVProgressHUDAnimationType defaultAnimationType UI_APPEARANCE_SELECTOR;   // default is SVProgressHUDAnimationTypeFlat
-@property (assign, nonatomic) CGSize minimumSize UI_APPEARANCE_SELECTOR;        // default is CGSizeZero, can be used to avoid resizing for a larger message
-@property (assign, nonatomic) CGFloat ringThickness UI_APPEARANCE_SELECTOR;     // default is 2 pt
-@property (assign, nonatomic) CGFloat ringRadius UI_APPEARANCE_SELECTOR;        // default is 18 pt
-@property (assign, nonatomic) CGFloat ringNoTextRadius UI_APPEARANCE_SELECTOR;  // default is 24 pt
-@property (assign, nonatomic) CGFloat cornerRadius UI_APPEARANCE_SELECTOR;      // default is 14 pt
-@property (strong, nonatomic) UIFont *font UI_APPEARANCE_SELECTOR;              // default is [UIFont preferredFontForTextStyle:UIFontTextStyleSubheadline]
-@property (strong, nonatomic) UIColor *backgroundColor UI_APPEARANCE_SELECTOR;  // default is [UIColor whiteColor]
-@property (strong, nonatomic) UIColor *foregroundColor UI_APPEARANCE_SELECTOR;  // default is [UIColor blackColor]
-@property (strong, nonatomic) UIImage *infoImage UI_APPEARANCE_SELECTOR;        // default is the bundled info image provided by Freepik
-@property (strong, nonatomic) UIImage *successImage UI_APPEARANCE_SELECTOR;     // default is the bundled success image provided by Freepik
-@property (strong, nonatomic) UIImage *errorImage UI_APPEARANCE_SELECTOR;       // default is the bundled error image provided by Freepik
-@property (strong, nonatomic) UIView *viewForExtension UI_APPEARANCE_SELECTOR;  // default is nil, only used if #define SV_APP_EXTENSIONS is set
-@property (assign, nonatomic) NSTimeInterval minimumDismissTimeInterval;        // default is 5.0 seconds
+@property (assign, nonatomic) CGSize minimumSize UI_APPEARANCE_SELECTOR;          // default is CGSizeZero, can be used to avoid resizing for a larger message
+@property (assign, nonatomic) CGFloat ringThickness UI_APPEARANCE_SELECTOR;       // default is 2 pt
+@property (assign, nonatomic) CGFloat ringRadius UI_APPEARANCE_SELECTOR;          // default is 18 pt
+@property (assign, nonatomic) CGFloat ringNoTextRadius UI_APPEARANCE_SELECTOR;    // default is 24 pt
+@property (assign, nonatomic) CGFloat cornerRadius UI_APPEARANCE_SELECTOR;        // default is 14 pt
+@property (strong, nonatomic) UIFont *font UI_APPEARANCE_SELECTOR;                // default is [UIFont preferredFontForTextStyle:UIFontTextStyleSubheadline]
+@property (strong, nonatomic) UIColor *backgroundColor UI_APPEARANCE_SELECTOR;    // default is [UIColor whiteColor]
+@property (strong, nonatomic) UIColor *foregroundColor UI_APPEARANCE_SELECTOR;    // default is [UIColor blackColor]
+@property (strong, nonatomic) UIImage *infoImage UI_APPEARANCE_SELECTOR;          // default is the bundled info image provided by Freepik
+@property (strong, nonatomic) UIImage *successImage UI_APPEARANCE_SELECTOR;       // default is the bundled success image provided by Freepik
+@property (strong, nonatomic) UIImage *errorImage UI_APPEARANCE_SELECTOR;         // default is the bundled error image provided by Freepik
+@property (strong, nonatomic) UIView *viewForExtension UI_APPEARANCE_SELECTOR;    // default is nil, only used if #define SV_APP_EXTENSIONS is set
+@property (assign, nonatomic) NSTimeInterval minimumDismissTimeInterval;          // default is 5.0 seconds
 
-@property (assign, nonatomic) UIOffset offsetFromCenter UI_APPEARANCE_SELECTOR; // default is 0, 0
+@property (assign, nonatomic) UIOffset offsetFromCenter UI_APPEARANCE_SELECTOR;   // default is 0, 0
+@property (strong, nonatomic) UIColor *dimBackgroundColor UI_APPEARANCE_SELECTOR; // default is [UIColor colorWithWhite:0 alpha:0.5]
+@property (assign, nonatomic) NSTimeInterval fadeInAnimationSpeed;  // default is 0.15
+@property (assign, nonatomic) NSTimeInterval fadeOutAnimationSpeed; // default is 0.15
+
 
 + (void)setDefaultStyle:(SVProgressHUDStyle)style;                  // default is SVProgressHUDStyleLight
 + (void)setDefaultMaskType:(SVProgressHUDMaskType)maskType;         // default is SVProgressHUDMaskTypeNone
@@ -80,6 +84,9 @@ typedef NS_ENUM(NSUInteger, SVProgressHUDAnimationType) {
 + (void)setErrorImage:(UIImage*)image;                              // default is the bundled error image provided by Freepik
 + (void)setViewForExtension:(UIView*)view;                          // default is nil, only used if #define SV_APP_EXTENSIONS is set
 + (void)setMinimumDismissTimeInterval:(NSTimeInterval)interval;     // default is 5.0 seconds
++ (void)setDimBackgroundColor:(UIColor *)color;                     // default is [UIColor colorWithWhite:0 alpha:0.5]
++ (void)setFadeInAnimationSpeed:(NSTimeInterval)speed;              // default is 0.15
++ (void)setFadeOutAnimationSpeed:(NSTimeInterval)speed;             // default is 0.15
 
 #pragma mark - Show Methods
 

--- a/SVProgressHUD/SVProgressHUD.h
+++ b/SVProgressHUD/SVProgressHUD.h
@@ -48,22 +48,23 @@ typedef NS_ENUM(NSUInteger, SVProgressHUDAnimationType) {
 @property (assign, nonatomic) SVProgressHUDStyle defaultStyle UI_APPEARANCE_SELECTOR;                   // default is SVProgressHUDStyleLight
 @property (assign, nonatomic) SVProgressHUDMaskType defaultMaskType UI_APPEARANCE_SELECTOR;             // default is SVProgressHUDMaskTypeNone
 @property (assign, nonatomic) SVProgressHUDAnimationType defaultAnimationType UI_APPEARANCE_SELECTOR;   // default is SVProgressHUDAnimationTypeFlat
-@property (assign, nonatomic) CGSize minimumSize UI_APPEARANCE_SELECTOR;          // default is CGSizeZero, can be used to avoid resizing for a larger message
-@property (assign, nonatomic) CGFloat ringThickness UI_APPEARANCE_SELECTOR;       // default is 2 pt
-@property (assign, nonatomic) CGFloat ringRadius UI_APPEARANCE_SELECTOR;          // default is 18 pt
-@property (assign, nonatomic) CGFloat ringNoTextRadius UI_APPEARANCE_SELECTOR;    // default is 24 pt
-@property (assign, nonatomic) CGFloat cornerRadius UI_APPEARANCE_SELECTOR;        // default is 14 pt
-@property (strong, nonatomic) UIFont *font UI_APPEARANCE_SELECTOR;                // default is [UIFont preferredFontForTextStyle:UIFontTextStyleSubheadline]
-@property (strong, nonatomic) UIColor *backgroundColor UI_APPEARANCE_SELECTOR;    // default is [UIColor whiteColor]
-@property (strong, nonatomic) UIColor *foregroundColor UI_APPEARANCE_SELECTOR;    // default is [UIColor blackColor]
-@property (strong, nonatomic) UIImage *infoImage UI_APPEARANCE_SELECTOR;          // default is the bundled info image provided by Freepik
-@property (strong, nonatomic) UIImage *successImage UI_APPEARANCE_SELECTOR;       // default is the bundled success image provided by Freepik
-@property (strong, nonatomic) UIImage *errorImage UI_APPEARANCE_SELECTOR;         // default is the bundled error image provided by Freepik
-@property (strong, nonatomic) UIView *viewForExtension UI_APPEARANCE_SELECTOR;    // default is nil, only used if #define SV_APP_EXTENSIONS is set
-@property (assign, nonatomic) NSTimeInterval minimumDismissTimeInterval;          // default is 5.0 seconds
+@property (assign, nonatomic) CGSize minimumSize UI_APPEARANCE_SELECTOR;            // default is CGSizeZero, can be used to avoid resizing for a larger message
+@property (assign, nonatomic) CGFloat ringThickness UI_APPEARANCE_SELECTOR;         // default is 2 pt
+@property (assign, nonatomic) CGFloat ringRadius UI_APPEARANCE_SELECTOR;            // default is 18 pt
+@property (assign, nonatomic) CGFloat ringNoTextRadius UI_APPEARANCE_SELECTOR;      // default is 24 pt
+@property (assign, nonatomic) CGFloat cornerRadius UI_APPEARANCE_SELECTOR;          // default is 14 pt
+@property (strong, nonatomic) UIFont *font UI_APPEARANCE_SELECTOR;                  // default is [UIFont preferredFontForTextStyle:UIFontTextStyleSubheadline]
+@property (strong, nonatomic) UIColor *backgroundColor UI_APPEARANCE_SELECTOR;      // default is [UIColor whiteColor]
+@property (strong, nonatomic) UIColor *foregroundColor UI_APPEARANCE_SELECTOR;      // default is [UIColor blackColor]
+@property (strong, nonatomic) UIColor *backgroundLayerColor UI_APPEARANCE_SELECTOR; // default is [UIColor colorWithWhite:0 alpha:0.5]
+@property (strong, nonatomic) UIImage *infoImage UI_APPEARANCE_SELECTOR;            // default is the bundled info image provided by Freepik
+@property (strong, nonatomic) UIImage *successImage UI_APPEARANCE_SELECTOR;         // default is the bundled success image provided by Freepik
+@property (strong, nonatomic) UIImage *errorImage UI_APPEARANCE_SELECTOR;           // default is the bundled error image provided by Freepik
+@property (strong, nonatomic) UIView *viewForExtension UI_APPEARANCE_SELECTOR;      // default is nil, only used if #define SV_APP_EXTENSIONS is set
+@property (assign, nonatomic) NSTimeInterval minimumDismissTimeInterval;            // default is 5.0 seconds
 
-@property (assign, nonatomic) UIOffset offsetFromCenter UI_APPEARANCE_SELECTOR;   // default is 0, 0
-@property (strong, nonatomic) UIColor *dimBackgroundColor UI_APPEARANCE_SELECTOR; // default is [UIColor colorWithWhite:0 alpha:0.5]
+@property (assign, nonatomic) UIOffset offsetFromCenter UI_APPEARANCE_SELECTOR;     // default is 0, 0
+
 @property (assign, nonatomic) NSTimeInterval fadeInAnimationSpeed;  // default is 0.15
 @property (assign, nonatomic) NSTimeInterval fadeOutAnimationSpeed; // default is 0.15
 
@@ -79,12 +80,12 @@ typedef NS_ENUM(NSUInteger, SVProgressHUDAnimationType) {
 + (void)setFont:(UIFont*)font;                                      // default is [UIFont preferredFontForTextStyle:UIFontTextStyleSubheadline]
 + (void)setForegroundColor:(UIColor*)color;                         // default is [UIColor blackColor], only used for SVProgressHUDStyleCustom
 + (void)setBackgroundColor:(UIColor*)color;                         // default is [UIColor whiteColor], only used for SVProgressHUDStyleCustom
++ (void)setBackgroundLayerColor:(UIColor *)color;                   // default is [UIColor colorWithWhite:0 alpha:0.5], only used for SVProgressHUDMaskTypeBlack
 + (void)setInfoImage:(UIImage*)image;                               // default is the bundled info image provided by Freepik
 + (void)setSuccessImage:(UIImage*)image;                            // default is the bundled success image provided by Freepik
 + (void)setErrorImage:(UIImage*)image;                              // default is the bundled error image provided by Freepik
 + (void)setViewForExtension:(UIView*)view;                          // default is nil, only used if #define SV_APP_EXTENSIONS is set
 + (void)setMinimumDismissTimeInterval:(NSTimeInterval)interval;     // default is 5.0 seconds
-+ (void)setDimBackgroundColor:(UIColor *)color;                     // default is [UIColor colorWithWhite:0 alpha:0.5]
 + (void)setFadeInAnimationSpeed:(NSTimeInterval)speed;              // default is 0.15
 + (void)setFadeOutAnimationSpeed:(NSTimeInterval)speed;             // default is 0.15
 

--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -175,6 +175,18 @@ static const CGFloat SVProgressHUDDefaultAnimationDuration = 0.15;
     [self sharedView].minimumDismissTimeInterval = interval;
 }
 
++ (void)setDimBackgroundColor:(UIColor *)color {
+    [self sharedView].dimBackgroundColor = color;
+}
+
++ (void)setFadeInAnimationSpeed:(NSTimeInterval)speed {
+    [self sharedView].fadeInAnimationSpeed = speed;
+}
+
++ (void)setFadeOutAnimationSpeed:(NSTimeInterval)speed {
+    [self sharedView].fadeOutAnimationSpeed = speed;
+}
+
 
 #pragma mark - Show Methods
 
@@ -288,7 +300,9 @@ static const CGFloat SVProgressHUDDefaultAnimationDuration = 0.15;
 }
 
 + (void)dismissWithDelay:(NSTimeInterval)delay {
-    [SVProgressHUD dismissWithDuration:SVProgressHUDDefaultAnimationDuration delay:delay];
+    if([self isVisible]) {
+        [[self sharedView] dismissWithDelay:delay];
+    }
 }
 
 + (void)dismissWithDuration:(NSTimeInterval)duration delay:(NSTimeInterval)delay {
@@ -357,6 +371,10 @@ static const CGFloat SVProgressHUDDefaultAnimationDuration = 0.15;
         _cornerRadius = 14.0f;
         
         _minimumDismissTimeInterval = 5.0;
+
+        _dimBackgroundColor = [UIColor colorWithWhite:0 alpha:0.5];
+        _fadeInAnimationSpeed = SVProgressHUDDefaultAnimationDuration;
+        _fadeOutAnimationSpeed = SVProgressHUDDefaultAnimationDuration;
         
         // Accessibility support
         self.accessibilityIdentifier = @"SVProgressHUD";
@@ -486,7 +504,7 @@ static const CGFloat SVProgressHUDDefaultAnimationDuration = 0.15;
             
             self.backgroundLayer = [CALayer layer];
             self.backgroundLayer.frame = self.bounds;
-            self.backgroundLayer.backgroundColor = [UIColor colorWithWhite:0 alpha:0.5].CGColor;
+            self.backgroundLayer.backgroundColor = self.dimBackgroundColor.CGColor;
             [self.backgroundLayer setNeedsDisplay];
             
             [self.layer insertSublayer:self.backgroundLayer atIndex:0];
@@ -951,7 +969,7 @@ static const CGFloat SVProgressHUDDefaultAnimationDuration = 0.15;
         
         // Animate appearance
         __weak SVProgressHUD *weakSelf = self;
-        [UIView animateWithDuration:SVProgressHUDDefaultAnimationDuration
+        [UIView animateWithDuration:self.fadeInAnimationSpeed
                               delay:0
                             options:(UIViewAnimationOptions) (UIViewAnimationOptionAllowUserInteraction | UIViewAnimationCurveEaseOut | UIViewAnimationOptionBeginFromCurrentState)
                          animations:^{
@@ -986,6 +1004,10 @@ static const CGFloat SVProgressHUDDefaultAnimationDuration = 0.15;
         // Inform iOS to redraw the view hierachy
         [self setNeedsDisplay];
     }
+}
+
+- (void)dismissWithDelay:(NSTimeInterval)delay {
+    [self dismissWithDuration:self.fadeOutAnimationSpeed delay:delay];
 }
 
 - (void)dismissWithDuration:(NSTimeInterval)duration delay:(NSTimeInterval)delay {
@@ -1063,7 +1085,7 @@ static const CGFloat SVProgressHUDDefaultAnimationDuration = 0.15;
 }
 
 - (void)dismiss {
-    [self dismissWithDuration:SVProgressHUDDefaultAnimationDuration delay:0];
+    [self dismissWithDuration:self.fadeOutAnimationSpeed delay:0];
 }
 
 

--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -155,6 +155,10 @@ static const CGFloat SVProgressHUDDefaultAnimationDuration = 0.15;
     [self sharedView].backgroundColor = color;
 }
 
++ (void)setBackgroundLayerColor:(UIColor *)color {
+    [self sharedView].backgroundLayerColor = color;
+}
+
 + (void)setInfoImage:(UIImage*)image {
     [self sharedView].infoImage = image;
 }
@@ -173,10 +177,6 @@ static const CGFloat SVProgressHUDDefaultAnimationDuration = 0.15;
 
 + (void)setMinimumDismissTimeInterval:(NSTimeInterval)interval {
     [self sharedView].minimumDismissTimeInterval = interval;
-}
-
-+ (void)setDimBackgroundColor:(UIColor *)color {
-    [self sharedView].dimBackgroundColor = color;
 }
 
 + (void)setFadeInAnimationSpeed:(NSTimeInterval)speed {
@@ -332,6 +332,7 @@ static const CGFloat SVProgressHUDDefaultAnimationDuration = 0.15;
         self.userInteractionEnabled = NO;
         _backgroundColor = [UIColor clearColor];
         _foregroundColor = [UIColor blackColor];
+        _backgroundLayerColor = [UIColor colorWithWhite:0 alpha:0.5];
         self.alpha = 0.0f;
         self.activityCount = 0;
         
@@ -372,7 +373,6 @@ static const CGFloat SVProgressHUDDefaultAnimationDuration = 0.15;
         
         _minimumDismissTimeInterval = 5.0;
 
-        _dimBackgroundColor = [UIColor colorWithWhite:0 alpha:0.5];
         _fadeInAnimationSpeed = SVProgressHUDDefaultAnimationDuration;
         _fadeOutAnimationSpeed = SVProgressHUDDefaultAnimationDuration;
         
@@ -504,7 +504,7 @@ static const CGFloat SVProgressHUDDefaultAnimationDuration = 0.15;
             
             self.backgroundLayer = [CALayer layer];
             self.backgroundLayer.frame = self.bounds;
-            self.backgroundLayer.backgroundColor = self.dimBackgroundColor.CGColor;
+            self.backgroundLayer.backgroundColor = self.backgroundLayerColor.CGColor;
             [self.backgroundLayer setNeedsDisplay];
             
             [self.layer insertSublayer:self.backgroundLayer atIndex:0];


### PR DESCRIPTION
Allows apps to customize the color/opacity of the dimmed background when using SVProgressHUDMaskTypeBlack

Allows apps to customize the fade-in and fade-out animation speed (without calling dismissWithDuration: everywhere)

https://github.com/SVProgressHUD/SVProgressHUD/issues/564