### PR TITLE
Fixed problem where displayDurationForString can return duration shoter than minimumDismissTimeInterval

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -1176,7 +1176,7 @@ static const CGFloat SVProgressHUDDefaultAnimationDuration = 0.15;
 
 #pragma mark - Getters
 + (NSTimeInterval)displayDurationForString:(NSString*)string {
-    return MIN((float)string.length * 0.06 + 0.5, [self sharedView].minimumDismissTimeInterval);
+    return MAX((float)string.length * 0.06 + 0.5, [self sharedView].minimumDismissTimeInterval);
 }
 
 - (UIColor *)foregroundColorForStyle {


### PR DESCRIPTION
DisplayDurationForString can return value less than minimumDismissTimeInterval.

Changed 

` return MIN((float)string.length * 0.06 + 0.5, [self sharedView].minimumDismissTimeInterval);`

to

` return MAX((float)string.length * 0.06 + 0.5, [self sharedView].minimumDismissTimeInterval);`