### PR TITLE
Reset ring layer stroke end upon dismiss

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -300,15 +300,19 @@ static const CGFloat SVProgressHUDDefaultAnimationDuration = 0.15;
 }
 
 + (void)dismissWithDelay:(NSTimeInterval)delay {
-    if([self isVisible]) {
-        [[self sharedView] dismissWithDelay:delay];
-    }
+    [[NSOperationQueue mainQueue] addOperationWithBlock:^{
+        if([self isVisible]) {
+            [[self sharedView] dismissWithDelay:delay];
+        }
+    }];
 }
 
 + (void)dismissWithDuration:(NSTimeInterval)duration delay:(NSTimeInterval)delay {
-    if([self isVisible]) {
-        [[self sharedView] dismissWithDuration:duration delay:delay];
-    }
+    [[NSOperationQueue mainQueue] addOperationWithBlock:^{
+        if([SVProgressHUD isVisible]) {
+            [[SVProgressHUD sharedView] dismissWithDuration:duration delay:delay];
+        }
+    }];
 }
 
 

--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -1034,6 +1034,7 @@ static const CGFloat SVProgressHUDDefaultAnimationDuration = 0.15;
             __strong SVProgressHUD *strongSelf = weakSelf;
             if(strongSelf) {
                 // Clean up view hierachy (overlays)
+                strongSelf.ringLayer.strokeEnd = 0.0f;
                 [strongSelf.overlayView removeFromSuperview];
                 [strongSelf.hudView removeFromSuperview];
                 [strongSelf removeFromSuperview];


### PR DESCRIPTION
This fixes a minor visual bug, where if you first display progress indicator with values btw 0..1, and then display the progress indicator again starting at 0, the progress momentarily shows 1 (and immediately animates back to 0).    