### PR TITLE
Fix for duplicate symbols error when building from CocoaPods

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -75,8 +75,6 @@ static const CGFloat SVProgressHUDDefaultAnimationDuration = 0.15;
 - (void)dismissWithDelay:(NSTimeInterval)delay;
 
 - (UIView*)indefiniteAnimatedView;
-- (UIView*)ringView;
-- (UIView*)backgroundRingView;
 
 - (void)cancelRingLayerAnimation;
 - (void)cancelIndefiniteAnimatedViewAnimation;


### PR DESCRIPTION
Fix duplicate symbol errors by removing extra declaration of ringView… and backgroundRingView getters.