### PR TITLE
Adds maxWindow property, uses keyWindow for setting frame

### DIFF
--- a/SVProgressHUD/SVProgressHUD.h
+++ b/SVProgressHUD/SVProgressHUD.h
@@ -68,6 +68,7 @@ typedef NS_ENUM(NSUInteger, SVProgressHUDAnimationType) {
 
 @property (assign, nonatomic) NSTimeInterval fadeInAnimationDuration;  // default is 0.15
 @property (assign, nonatomic) NSTimeInterval fadeOutAnimationDuration; // default is 0.15
+@property (assign, nonatomic) CGFloat maxWindowLevel; // default is UIWindowLevelNormal
 
 
 + (void)setDefaultStyle:(SVProgressHUDStyle)style;                  // default is SVProgressHUDStyleLight
@@ -89,6 +90,7 @@ typedef NS_ENUM(NSUInteger, SVProgressHUDAnimationType) {
 + (void)setMinimumDismissTimeInterval:(NSTimeInterval)interval;     // default is 5.0 seconds
 + (void)setFadeInAnimationDuration:(NSTimeInterval)duration;        // default is 0.15 seconds
 + (void)setFadeOutAnimationDuration:(NSTimeInterval)duration;       // default is 0.15 seconds
++ (void)setMaxWindowLevel:(CGFloat)windowLevel;                     // default is UIWindowLevelNormal
 
 #pragma mark - Show Methods
 

--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -187,6 +187,10 @@ static const CGFloat SVProgressHUDDefaultAnimationDuration = 0.15;
     [self sharedView].fadeOutAnimationDuration = duration;
 }
 
++ (void)setMaxWindowLevel:(CGFloat)windowLevel {
+    [self sharedView].maxWindowLevel = windowLevel;
+}
+
 
 #pragma mark - Show Methods
 
@@ -593,8 +597,9 @@ static const CGFloat SVProgressHUDDefaultAnimationDuration = 0.15;
             BOOL windowOnMainScreen = window.screen == UIScreen.mainScreen;
             BOOL windowIsVisible = !window.hidden && window.alpha > 0;
             BOOL windowLevelNormal = window.windowLevel == UIWindowLevelNormal;
+            BOOL windowLevelFlag = self.maxWindowLevel != 0 ? (window.windowLevel <= self.maxWindowLevel) : windowLevelNormal;
             
-            if(windowOnMainScreen && windowIsVisible && windowLevelNormal) {
+            if(windowOnMainScreen && windowIsVisible && windowLevelFlag) {
                 [window addSubview:self.overlayView];
                 break;
             }
@@ -681,7 +686,7 @@ static const CGFloat SVProgressHUDDefaultAnimationDuration = 0.15;
     double animationDuration = 0.0;
 
 #if !defined(SV_APP_EXTENSIONS) && TARGET_OS_IOS
-    self.frame = [[[UIApplication sharedApplication] delegate] window].bounds;
+    self.frame = [UIApplication sharedApplication].keyWindow.bounds;
     UIInterfaceOrientation orientation = UIApplication.sharedApplication.statusBarOrientation;
 #elif !defined(SV_APP_EXTENSIONS)
     self.frame = [UIApplication sharedApplication].keyWindow.bounds;
@@ -1397,6 +1402,10 @@ static const CGFloat SVProgressHUDDefaultAnimationDuration = 0.15;
 
 - (void)setFadeOutAnimationDuration:(NSTimeInterval)duration  {
     if (!_isInitializing) _fadeOutAnimationDuration = duration;
+}
+
+- (void)setMaxWindowLevel:(CGFloat)windowLevel {
+    if (!_isInitializing) _maxWindowLevel = windowLevel;
 }
 
 @end


### PR DESCRIPTION
Added maxWindow property that defaults to UIWindowLevelNormal. This offers support for a project that uses multiple windows. 

Use keyWindow when setting self.frame in `positionHud:` . If main window is not keyWindow its frame may not be the full screen, especially if if the keyWIndow is a different orientation.

Thanks!