### PR TITLE
Fix overlay bounds to mask events after window resize

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -602,6 +602,7 @@ static const CGFloat SVProgressHUDDefaultAnimationDuration = 0.15;
             BOOL windowLevelNormal = window.windowLevel == UIWindowLevelNormal;
             
             if(windowOnMainScreen && windowIsVisible && windowLevelNormal) {
+                self.overlayView.frame = window.bounds;
                 [window addSubview:self.overlayView];
                 break;
             }


### PR DESCRIPTION
on 2.0.3 tag, the overlay is not autoresized while HUD is dismissed.

example steps to reproduce:

1. setDefaultMaskType to .Black
2. show and dismiss HUD in portrait screen
3. make the device landscape while HUD is dismissed
4. show HUD in landscape screen
5. on right side of the window, user interactions are pass through to views below.

at step 5, the overlay.frame is still portrait because autoresizing is happened while the overlay is not in the window view hierarchy.

this is also reproducible on multitasking split view.