### PR TITLE
activityCount increment fix

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -871,11 +871,6 @@ static const CGFloat SVProgressHUDDefaultAnimationDuration = 0.15;
                 [strongSelf.hudView addSubview:strongSelf.ringView];
                 [strongSelf.hudView addSubview:strongSelf.backgroundRingView];
                 strongSelf.ringView.strokeEnd = progress;
-                
-                // Update the activity count
-                if(progress == 0) {
-                    strongSelf.activityCount++;
-                }
             } else {
                 // Cancel the ringLayer animation, then show the indefiniteAnimatedView
                 [strongSelf cancelRingLayerAnimation];
@@ -885,10 +880,10 @@ static const CGFloat SVProgressHUDDefaultAnimationDuration = 0.15;
                 if([strongSelf.indefiniteAnimatedView respondsToSelector:@selector(startAnimating)]) {
                     [(id)strongSelf.indefiniteAnimatedView startAnimating];
                 }
-                
-                // Update the activity count
-                strongSelf.activityCount++;
             }
+            
+            // Update the activity count
+            strongSelf.activityCount++;
             
             // Show
             [strongSelf showStatus:status];


### PR DESCRIPTION
`activityCount` could only have a maximum value of `1` with the current logic. This change ensures that `activityCount` accurately reflects the number of shown HUDs.