### PR TITLE
Implicitly set default style to custom when setting foreground or background colors.

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -149,10 +149,12 @@ static const CGFloat SVProgressHUDDefaultAnimationDuration = 0.15;
 
 + (void)setForegroundColor:(UIColor*)color {
     [self sharedView].foregroundColor = color;
+    [self setDefaultStyle:(SVProgressHUDStyle)SVProgressHUDStyleCustom];
 }
 
 + (void)setBackgroundColor:(UIColor*)color {
     [self sharedView].backgroundColor = color;
+    [self setDefaultStyle:(SVProgressHUDStyle)SVProgressHUDStyleCustom];
 }
 
 + (void)setBackgroundLayerColor:(UIColor*)color {


### PR DESCRIPTION
While setting the foreground and background color requires setting default style to custom, it is convenient to implicitly set the style upon calling `setForegroundColor` and `setBackgroundColor`.

It's less confusing for devs, and should be the excepted behaviour. (you set a color, you except it to change.)