### PR TITLE
Fixed #623

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -304,12 +304,14 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
 #pragma mark - Dismiss Methods
 
 + (void)popActivity {
-    if([self sharedView].activityCount > 0) {
-        [self sharedView].activityCount--;
-    }
-    if([self sharedView].activityCount == 0) {
-        [[self sharedView] dismiss];
-    }
+    [[NSOperationQueue mainQueue] addOperationWithBlock:^{
+        if([self sharedView].activityCount > 0) {
+            [self sharedView].activityCount--;
+        }
+        if([self sharedView].activityCount == 0) {
+            [[self sharedView] dismiss];
+        }
+    }];
 }
 
 + (void)dismiss {


### PR DESCRIPTION
popActivity not working as expected
There was a problem with popActivity workflow. In previous version it
never went in first “if condition” because of block in “-
(void)showProgress:(float)progress status:(NSString*)status;” function,
and worked not as in README file described;
My changes helps to make decrement of “activityCount” in case,
described in #623 issue instead of dismissing, and then everything
works fine.