### PR TITLE
Fixed #623

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -787,15 +787,15 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
                 if([strongSelf.indefiniteAnimatedView respondsToSelector:@selector(startAnimating)]) {
                     [(id)strongSelf.indefiniteAnimatedView startAnimating];
                 }
-                
-                // Update the activity count
-                strongSelf.activityCount++;
             }
             
             // Show
             [strongSelf showStatus:status];
         }
     }];
+    
+    // Update the activity count
+    weakSelf.activityCount++;
 }
 
 - (void)showImage:(UIImage*)image status:(NSString*)status duration:(NSTimeInterval)duration {


### PR DESCRIPTION
popActivity not working as expected
ActivityCount incrementation have to be out of block.
PopActivity can’t see value of activityCount because of main Queue.
Block with incrementing will call after checking activityCount value.