### PR TITLE
Add a callback for HUD show completion

### DIFF
--- a/Demo/Classes/ViewController.m
+++ b/Demo/Classes/ViewController.m
@@ -93,13 +93,18 @@ static float progress = 0.0f;
 }
 
 - (void)showSuccessWithStatus {
-	[SVProgressHUD showSuccessWithStatus:@"Great Success!"];
+    [SVProgressHUD showSuccessWithStatus:@"Great Success!"];
 }
 
 - (void)showErrorWithStatus {
 	[SVProgressHUD showErrorWithStatus:@"Failed with Error"];
 }
 
+- (IBAction)showErrorWithStatusWithCompletion:(id)sender {
+    [SVProgressHUD showErrorWithStatus:@"Failed with Error" completion:^{
+        NSLog(@"Failed with Error: has been shown to complete");
+    }];
+}
 
 #pragma mark - Styling
 

--- a/Demo/ViewController.xib
+++ b/Demo/ViewController.xib
@@ -1,9 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11542" systemVersion="16B2657" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" colorMatched="NO">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="15G1004" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment version="1792" identifier="iOS"/>
-        <development version="7000" identifier="xcode"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11524"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ViewController">
@@ -16,12 +19,12 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="460"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="10">
-                    <rect key="frame" x="30" y="87" width="260" height="30"/>
+                <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="10">
+                    <rect key="frame" x="30" y="48" width="260" height="30"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <state key="normal" title="showWithStatus:">
-                        <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="calibratedRGB"/>
+                        <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                     </state>
                     <connections>
                         <action selector="showWithStatus" destination="-1" eventType="touchUpInside" id="20"/>
@@ -32,62 +35,62 @@
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <state key="normal" title="dismiss">
-                        <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="calibratedRGB"/>
+                        <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                     </state>
                     <connections>
                         <action selector="dismiss" destination="-1" eventType="touchUpInside" id="16"/>
                     </connections>
                 </button>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="14">
-                    <rect key="frame" x="30" y="201" width="260" height="30"/>
+                <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="14">
+                    <rect key="frame" x="30" y="162" width="260" height="30"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <state key="normal" title="showSuccessWithStatus:">
-                        <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="calibratedRGB"/>
+                        <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                     </state>
                     <connections>
                         <action selector="showSuccessWithStatus" destination="-1" eventType="touchUpInside" id="Qy5-B6-P8U"/>
                     </connections>
                 </button>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="xYZ-FY-Azt">
-                    <rect key="frame" x="30" y="163" width="260" height="30"/>
+                <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="xYZ-FY-Azt">
+                    <rect key="frame" x="30" y="124" width="260" height="30"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <state key="normal" title="showInfoWithStatus:">
-                        <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="calibratedRGB"/>
+                        <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                     </state>
                     <connections>
                         <action selector="showInfoWithStatus" destination="-1" eventType="touchUpInside" id="bAB-g7-x4I"/>
                     </connections>
                 </button>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="15">
-                    <rect key="frame" x="30" y="239" width="260" height="30"/>
+                <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="15">
+                    <rect key="frame" x="30" y="200" width="260" height="30"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <state key="normal" title="showErrorWithStatus:">
-                        <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="calibratedRGB"/>
+                        <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                     </state>
                     <connections>
                         <action selector="showErrorWithStatus" destination="-1" eventType="touchUpInside" id="FBA-eb-OWF"/>
                     </connections>
                 </button>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="27">
-                    <rect key="frame" x="30" y="125" width="260" height="30"/>
+                <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="27">
+                    <rect key="frame" x="30" y="86" width="260" height="30"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <state key="normal" title="showWithProgress:">
-                        <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="calibratedRGB"/>
+                        <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                     </state>
                     <connections>
                         <action selector="showWithProgress:" destination="-1" eventType="touchUpInside" id="29"/>
                     </connections>
                 </button>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="9">
-                    <rect key="frame" x="30" y="49" width="260" height="30"/>
+                <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="9">
+                    <rect key="frame" x="30" y="10" width="260" height="30"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <state key="normal" title="show">
-                        <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="calibratedRGB"/>
+                        <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                     </state>
                     <connections>
                         <action selector="show" destination="-1" eventType="touchUpInside" id="19"/>
@@ -150,8 +153,19 @@
                         <action selector="changeMaskType:" destination="-1" eventType="valueChanged" id="LO1-CN-ds3"/>
                     </connections>
                 </segmentedControl>
+                <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="4nM-QQ-dQh">
+                    <rect key="frame" x="30" y="238" width="260" height="33"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <state key="normal" title="showErrorWithStatus:completion">
+                        <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                    </state>
+                    <connections>
+                        <action selector="showErrorWithStatusWithCompletion:" destination="-1" eventType="touchUpInside" id="qkK-YP-nua"/>
+                    </connections>
+                </button>
             </subviews>
-            <color key="backgroundColor" red="0.89999997615814209" green="0.89999997615814209" blue="0.89999997615814209" alpha="1" colorSpace="calibratedRGB"/>
+            <color key="backgroundColor" red="0.89999997615814209" green="0.89999997615814209" blue="0.89999997615814209" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <nil key="simulatedStatusBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <point key="canvasLocation" x="16" y="388"/>
@@ -160,6 +174,6 @@
     <simulatedMetricsContainer key="defaultSimulatedMetrics">
         <simulatedStatusBarMetrics key="statusBar"/>
         <simulatedOrientationMetrics key="orientation"/>
-        <simulatedScreenMetrics key="destination"/>
+        <simulatedScreenMetrics key="destination" type="retina4_7.fullscreen"/>
     </simulatedMetricsContainer>
 </document>

--- a/SVProgressHUD/SVProgressHUD.h
+++ b/SVProgressHUD/SVProgressHUD.h
@@ -102,28 +102,44 @@ typedef void (^SVProgressHUDDismissCompletion)(void);
 #pragma mark - Show Methods
 
 + (void)show;
++ (void)showWithCompletion:(SVProgressHUDShowCompletion)completion;
 + (void)showWithMaskType:(SVProgressHUDMaskType)maskType __attribute__((deprecated("Use show and setDefaultMaskType: instead.")));
++ (void)showWithMaskType:(SVProgressHUDMaskType)maskType completion:(SVProgressHUDShowCompletion)completion __attribute__((deprecated("Use showWithCompletion: and setDefaultMaskType: instead.")));
 + (void)showWithStatus:(NSString*)status;
++ (void)showWithStatus:(NSString*)status completion:(SVProgressHUDShowCompletion)completion;
 + (void)showWithStatus:(NSString*)status maskType:(SVProgressHUDMaskType)maskType __attribute__((deprecated("Use showWithStatus: and setDefaultMaskType: instead.")));
++ (void)showWithStatus:(NSString*)status maskType:(SVProgressHUDMaskType)maskType completion:(SVProgressHUDShowCompletion)completion __attribute__((deprecated("Use showWithStatus:completion: and setDefaultMaskType: instead.")));
 
 + (void)showProgress:(float)progress;
++ (void)showProgress:(float)progress completion:(SVProgressHUDShowCompletion)completion;
 + (void)showProgress:(float)progress maskType:(SVProgressHUDMaskType)maskType __attribute__((deprecated("Use showProgress: and setDefaultMaskType: instead.")));
++ (void)showProgress:(float)progress maskType:(SVProgressHUDMaskType)maskType completion:(SVProgressHUDShowCompletion)completion __attribute__((deprecated("Use showProgress:completion: and setDefaultMaskType: instead.")));
 + (void)showProgress:(float)progress status:(NSString*)status;
++ (void)showProgress:(float)progress status:(NSString*)status completion:(SVProgressHUDShowCompletion)completion;
 + (void)showProgress:(float)progress status:(NSString*)status maskType:(SVProgressHUDMaskType)maskType __attribute__((deprecated("Use showProgress:status: and setDefaultMaskType: instead.")));
++ (void)showProgress:(float)progress status:(NSString*)status maskType:(SVProgressHUDMaskType)maskType completion:(SVProgressHUDShowCompletion)completion __attribute__((deprecated("Use showProgress:status:completion: and setDefaultMaskType: instead.")));
 
 + (void)setStatus:(NSString*)status; // change the HUD loading status while it's showing
 
 // stops the activity indicator, shows a glyph + status, and dismisses the HUD a little bit later
 + (void)showInfoWithStatus:(NSString*)status;
++ (void)showInfoWithStatus:(NSString*)status completion:(SVProgressHUDShowCompletion)completion;
 + (void)showInfoWithStatus:(NSString*)status maskType:(SVProgressHUDMaskType)maskType __attribute__((deprecated("Use showInfoWithStatus: and setDefaultMaskType: instead.")));
++ (void)showInfoWithStatus:(NSString*)status maskType:(SVProgressHUDMaskType)maskType completion:(SVProgressHUDShowCompletion)completion __attribute__((deprecated("Use showInfoWithStatus:completion: and setDefaultMaskType: instead.")));
 + (void)showSuccessWithStatus:(NSString*)status;
++ (void)showSuccessWithStatus:(NSString*)status completion:(SVProgressHUDShowCompletion)completion;
 + (void)showSuccessWithStatus:(NSString*)status maskType:(SVProgressHUDMaskType)maskType __attribute__((deprecated("Use showSuccessWithStatus: and setDefaultMaskType: instead.")));
++ (void)showSuccessWithStatus:(NSString*)status maskType:(SVProgressHUDMaskType)maskType completion:(SVProgressHUDShowCompletion)completion __attribute__((deprecated("Use showSuccessWithStatus:completion: and setDefaultMaskType: instead.")));
 + (void)showErrorWithStatus:(NSString*)status;
++ (void)showErrorWithStatus:(NSString*)status completion:(SVProgressHUDShowCompletion)completion;
 + (void)showErrorWithStatus:(NSString*)status maskType:(SVProgressHUDMaskType)maskType __attribute__((deprecated("Use showErrorWithStatus: and setDefaultMaskType: instead.")));
++ (void)showErrorWithStatus:(NSString*)status maskType:(SVProgressHUDMaskType)maskType completion:(SVProgressHUDShowCompletion)completion __attribute__((deprecated("Use showErrorWithStatus:completion: and setDefaultMaskType: instead.")));
 
 // shows a image + status, use 28x28 white PNGs
 + (void)showImage:(UIImage*)image status:(NSString*)status;
++ (void)showImage:(UIImage*)image status:(NSString*)status completion:(SVProgressHUDShowCompletion)completion;
 + (void)showImage:(UIImage*)image status:(NSString*)status maskType:(SVProgressHUDMaskType)maskType __attribute__((deprecated("Use showImage:status: and setDefaultMaskType: instead.")));
++ (void)showImage:(UIImage*)image status:(NSString*)status maskType:(SVProgressHUDMaskType)maskType completion:(SVProgressHUDShowCompletion)completion __attribute__((deprecated("Use showImage:status:completion: and setDefaultMaskType: instead.")));
 
 + (void)setOffsetFromCenter:(UIOffset)offset;
 + (void)resetOffsetFromCenter;

--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -61,6 +61,8 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
 @property (nonatomic, readonly) CGFloat visibleKeyboardHeight;
 @property (nonatomic, readonly) UIWindow *frontWindow;
 
+@property (nonatomic, copy) SVProgressHUDShowCompletion completionBlock;
+
 - (void)updateHUDFrame;
 
 #if TARGET_OS_IOS
@@ -213,97 +215,168 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
 #pragma mark - Show Methods
 
 + (void)show {
-    [self showWithStatus:nil];
+    [self showWithCompletion:nil];
+}
+
++ (void)showWithCompletion:(SVProgressHUDShowCompletion)completion {
+    [self showWithStatus:nil completion:completion];
 }
 
 + (void)showWithMaskType:(SVProgressHUDMaskType)maskType {
+    [self showWithMaskType:maskType completion:nil];
+}
+
++ (void)showWithMaskType:(SVProgressHUDMaskType)maskType completion:(SVProgressHUDShowCompletion)completion {
     SVProgressHUDMaskType existingMaskType = [self sharedView].defaultMaskType;
     [self setDefaultMaskType:maskType];
-    [self show];
+    [self showWithCompletion:completion];
     [self setDefaultMaskType:existingMaskType];
 }
 
 + (void)showWithStatus:(NSString*)status {
-    [self showProgress:SVProgressHUDUndefinedProgress status:status];
+    [self showWithStatus:status completion:nil];
+}
+
++ (void)showWithStatus:(NSString*)status completion:(SVProgressHUDShowCompletion)completion {
+    [self showProgress:SVProgressHUDUndefinedProgress status:status completion:completion];
 }
 
 + (void)showWithStatus:(NSString*)status maskType:(SVProgressHUDMaskType)maskType {
+    [self showWithStatus:status maskType:maskType completion:nil];
+}
+
++ (void)showWithStatus:(NSString*)status maskType:(SVProgressHUDMaskType)maskType completion:(SVProgressHUDShowCompletion)completion {
     SVProgressHUDMaskType existingMaskType = [self sharedView].defaultMaskType;
     [self setDefaultMaskType:maskType];
-    [self showWithStatus:status];
+    [self showWithStatus:status completion:completion];
     [self setDefaultMaskType:existingMaskType];
 }
 
 + (void)showProgress:(float)progress {
-    [self showProgress:progress status:nil];
+    [self showProgress:progress completion:nil];
+}
+
++ (void)showProgress:(float)progress completion:(SVProgressHUDShowCompletion)completion {
+    [self showProgress:progress status:nil completion:completion];
 }
 
 + (void)showProgress:(float)progress maskType:(SVProgressHUDMaskType)maskType {
+    [self showProgress:progress maskType:maskType completion:nil];
+}
+
++ (void)showProgress:(float)progress maskType:(SVProgressHUDMaskType)maskType completion:(SVProgressHUDShowCompletion)completion {
     SVProgressHUDMaskType existingMaskType = [self sharedView].defaultMaskType;
     [self setDefaultMaskType:maskType];
-    [self showProgress:progress];
+    [self showProgress:progress completion:completion];
     [self setDefaultMaskType:existingMaskType];
 }
 
 + (void)showProgress:(float)progress status:(NSString*)status {
+    [self showProgress:progress status:status completion:nil];
+}
+
++ (void)showProgress:(float)progress status:(NSString*)status completion:(SVProgressHUDShowCompletion)completion {
+    if ([self sharedView].completionBlock) {
+        [self sharedView].completionBlock();
+    }
+    [self sharedView].completionBlock = completion;
     [[self sharedView] showProgress:progress status:status];
 }
 
 + (void)showProgress:(float)progress status:(NSString*)status maskType:(SVProgressHUDMaskType)maskType {
-    SVProgressHUDMaskType existingMaskType = [self sharedView].defaultMaskType;
-    [self setDefaultMaskType:maskType];
-    [self showProgress:progress status:status];
-    [self setDefaultMaskType:existingMaskType];
+    [self showProgress:progress status:status maskType:maskType completion:nil];
 }
 
++ (void)showProgress:(float)progress status:(NSString*)status maskType:(SVProgressHUDMaskType)maskType completion:(SVProgressHUDShowCompletion)completion {
+    SVProgressHUDMaskType existingMaskType = [self sharedView].defaultMaskType;
+    [self setDefaultMaskType:maskType];
+    [self showProgress:progress status:status completion:completion];
+    [self setDefaultMaskType:existingMaskType];
+}
 
 #pragma mark - Show, then automatically dismiss methods
 
 + (void)showInfoWithStatus:(NSString*)status {
-    [self showImage:[self sharedView].infoImage status:status];
+    [self showInfoWithStatus:status completion:nil];
+}
+
++ (void)showInfoWithStatus:(NSString*)status completion:(SVProgressHUDShowCompletion)completion {
+    [self showImage:[self sharedView].infoImage status:status completion:completion];
 }
 
 + (void)showInfoWithStatus:(NSString*)status maskType:(SVProgressHUDMaskType)maskType {
+    [self showInfoWithStatus:status maskType:maskType completion:nil];
+}
+
++ (void)showInfoWithStatus:(NSString*)status maskType:(SVProgressHUDMaskType)maskType completion:(SVProgressHUDShowCompletion)completion {
     SVProgressHUDMaskType existingMaskType = [self sharedView].defaultMaskType;
     [self setDefaultMaskType:maskType];
-    [self showInfoWithStatus:status];
+    [self showInfoWithStatus:status completion:completion];
     [self setDefaultMaskType:existingMaskType];
 }
 
 + (void)showSuccessWithStatus:(NSString*)status {
-    [self showImage:[self sharedView].successImage status:status];
+    [self showSuccessWithStatus:status completion:nil];
+}
+
++ (void)showSuccessWithStatus:(NSString*)status completion:(SVProgressHUDShowCompletion)completion {
+    [self showImage:[self sharedView].successImage status:status completion:completion];
 }
 
 + (void)showSuccessWithStatus:(NSString*)status maskType:(SVProgressHUDMaskType)maskType {
+    [self showSuccessWithStatus:status maskType:maskType completion:nil];
+}
+
++ (void)showSuccessWithStatus:(NSString*)status maskType:(SVProgressHUDMaskType)maskType completion:(SVProgressHUDShowCompletion)completion {
     SVProgressHUDMaskType existingMaskType = [self sharedView].defaultMaskType;
     [self setDefaultMaskType:maskType];
-    [self showSuccessWithStatus:status];
+    [self showSuccessWithStatus:status completion:completion];
     [self setDefaultMaskType:existingMaskType];
 }
 
 + (void)showErrorWithStatus:(NSString*)status {
-    [self showImage:[self sharedView].errorImage status:status];
+    [self showErrorWithStatus:status completion:nil];
+}
+
++ (void)showErrorWithStatus:(NSString*)status completion:(SVProgressHUDShowCompletion)completion {
+    [self showImage:[self sharedView].errorImage status:status completion:completion];
 }
 
 + (void)showErrorWithStatus:(NSString*)status maskType:(SVProgressHUDMaskType)maskType {
+    [self showErrorWithStatus:status maskType:maskType completion:nil];
+}
+
++ (void)showErrorWithStatus:(NSString*)status maskType:(SVProgressHUDMaskType)maskType completion:(SVProgressHUDShowCompletion)completion {
     SVProgressHUDMaskType existingMaskType = [self sharedView].defaultMaskType;
     [self setDefaultMaskType:maskType];
-    [self showErrorWithStatus:status];
+    [self showErrorWithStatus:status completion:completion];
     [self setDefaultMaskType:existingMaskType];
 }
 
 + (void)showImage:(UIImage*)image status:(NSString*)status {
+    [self showImage:image status:status completion:nil];
+}
+
++ (void)showImage:(UIImage*)image status:(NSString*)status completion:(SVProgressHUDShowCompletion)completion {
+    if ([self sharedView].completionBlock) {
+        [self sharedView].completionBlock();
+    }
+    [self sharedView].completionBlock = completion;
+    
     NSTimeInterval displayInterval = [self displayDurationForString:status];
     [[self sharedView] showImage:image status:status duration:displayInterval];
 }
 
 + (void)showImage:(UIImage*)image status:(NSString*)status maskType:(SVProgressHUDMaskType)maskType {
-    SVProgressHUDMaskType existingMaskType = [self sharedView].defaultMaskType;
-    [self setDefaultMaskType:maskType];
-    [self showImage:image status:status];
-    [self setDefaultMaskType:existingMaskType];
+    [self showImage:image status:status maskType:maskType completion:nil];
 }
 
++ (void)showImage:(UIImage*)image status:(NSString*)status maskType:(SVProgressHUDMaskType)maskType completion:(SVProgressHUDShowCompletion)completion {
+    SVProgressHUDMaskType existingMaskType = [self sharedView].defaultMaskType;
+    [self setDefaultMaskType:maskType];
+    [self showImage:image status:status completion:completion];
+    [self setDefaultMaskType:existingMaskType];
+}
 
 #pragma mark - Dismiss Methods
 
@@ -329,6 +402,10 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
 }
 
 + (void)dismissWithDelay:(NSTimeInterval)delay completion:(SVProgressHUDDismissCompletion)completion {
+    if ([self sharedView].completionBlock) {
+        [self sharedView].completionBlock();
+        [self sharedView].completionBlock = nil;
+    }
     [[self sharedView] dismissWithDelay:delay completion:completion];
 }
 
@@ -1024,6 +1101,13 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
                     if (completion) {
                         completion();
                     }
+                    
+                    // Run a (optional) show completionHandler
+                    if (self.completionBlock) {
+                        self.completionBlock();
+                        self.completionBlock = nil;
+                    }
+                    
                 }
             };
                 


### PR DESCRIPTION
### Method of use

```
[SVProgressHUD showErrorWithStatus:@"Failed with Error" completion:^{
        NSLog(@"Failed with Error: has been shown to complete");
    }];
```
### Purpose

Sometimes we need to know SVProgressHUD display over time. Use the NSNotification observe, but SVProgressHUD is Singleton so don't know which HUD dismiss. Try adding judgment conditions, quite a trouble. Encounter this problem many times in the project, So I added these methods.

There may be not perfect place, please guide, thank you~

### Reference

I am so sorry, last time I did not feedback in time. 
I recently changed it again. look forward to~
