### PR TITLE
fix the bug 'first setMask SVProgressHUDMaskTypeBlack then setMask SV…

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -1244,6 +1244,7 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
             }
         }
         default:
+            _backgroundView.backgroundColor = [UIColor clearColor];
             break;
     }
     


### PR DESCRIPTION
if you setDefaultMaskType as  SVProgressHUDMaskTypeBlack,and then you setDefaultMaskType as SVProgressHUDMaskTypeNone or SVProgressHUDMaskTypeClear.The maskView is still the color when the masktype is SVProgressHUDMaskTypeBlack. So you should reset the backgroundView's color in the SVProgressHUD. 