### PR TITLE
Fix user interaction when default mask is SVProgressHUDMaskTypeNone

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -907,7 +907,7 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
         self.accessibilityLabel = status;
         self.isAccessibilityElement = YES;
     } else {
-        self.controlView.userInteractionEnabled = YES;
+        self.controlView.userInteractionEnabled = NO;
         self.hudView.accessibilityLabel = status;
         self.hudView.isAccessibilityElement = YES;
     }

--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -903,9 +903,11 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
     
     // Update accessibility as well as user interaction
     if(self.defaultMaskType != SVProgressHUDMaskTypeNone) {
+        self.controlView.userInteractionEnabled = YES;
         self.accessibilityLabel = status;
         self.isAccessibilityElement = YES;
     } else {
+        self.controlView.userInteractionEnabled = YES;
         self.hudView.accessibilityLabel = status;
         self.hudView.isAccessibilityElement = YES;
     }


### PR DESCRIPTION
I noticed SVProgressHUD was blocking background user interaction when it shouldn't be for the none mask.