### PR TITLE
Add @available macro to suppress warning in Xcode 9

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -57,7 +57,7 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
 @property (nonatomic, readonly) UIWindow *frontWindow;
 
 #if TARGET_OS_IOS && __IPHONE_OS_VERSION_MAX_ALLOWED >= 100000
-@property (nonatomic, strong) UINotificationFeedbackGenerator *hapticGenerator;
+@property (nonatomic, strong) UINotificationFeedbackGenerator *hapticGenerator NS_AVAILABLE_IOS(10_0);
 #endif
 
 @end
@@ -249,7 +249,11 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
     
 #if TARGET_OS_IOS && __IPHONE_OS_VERSION_MAX_ALLOWED >= 100000
     dispatch_async(dispatch_get_main_queue(), ^{
-        [[self sharedView].hapticGenerator notificationOccurred:UINotificationFeedbackTypeWarning];
+        if (@available(iOS 10_0, *)) {
+            [[self sharedView].hapticGenerator notificationOccurred:UINotificationFeedbackTypeWarning];
+        } else {
+            // Fallback on earlier versions
+        }
     });
 #endif
 }
@@ -266,7 +270,11 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
 
 #if TARGET_OS_IOS && __IPHONE_OS_VERSION_MAX_ALLOWED >= 100000
     dispatch_async(dispatch_get_main_queue(), ^{
-        [[self sharedView].hapticGenerator notificationOccurred:UINotificationFeedbackTypeSuccess];
+        if (@available(iOS 10_0, *)) {
+            [[self sharedView].hapticGenerator notificationOccurred:UINotificationFeedbackTypeSuccess];
+        } else {
+            // Fallback on earlier versions
+        }
     });
 #endif
 }
@@ -279,7 +287,11 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
     
 #if TARGET_OS_IOS && __IPHONE_OS_VERSION_MAX_ALLOWED >= 100000
     dispatch_async(dispatch_get_main_queue(), ^{
-        [[self sharedView].hapticGenerator notificationOccurred:UINotificationFeedbackTypeSuccess];
+        if (@available(iOS 10_0, *)) {
+            [[self sharedView].hapticGenerator notificationOccurred:UINotificationFeedbackTypeSuccess];
+        } else {
+            // Fallback on earlier versions
+        }
     });
 #endif
 }
@@ -289,7 +301,11 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
     
 #if TARGET_OS_IOS && __IPHONE_OS_VERSION_MAX_ALLOWED >= 100000
     dispatch_async(dispatch_get_main_queue(), ^{
-        [[self sharedView].hapticGenerator notificationOccurred:UINotificationFeedbackTypeError];
+        if (@available(iOS 10_0, *)) {
+            [[self sharedView].hapticGenerator notificationOccurred:UINotificationFeedbackTypeError];
+        } else {
+            // Fallback on earlier versions
+        }
     });
 #endif
 }
@@ -302,7 +318,11 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
     
 #if TARGET_OS_IOS && __IPHONE_OS_VERSION_MAX_ALLOWED >= 100000
     dispatch_async(dispatch_get_main_queue(), ^{
-        [[self sharedView].hapticGenerator notificationOccurred:UINotificationFeedbackTypeError];
+        if (@available(iOS 10_0, *)) {
+            [[self sharedView].hapticGenerator notificationOccurred:UINotificationFeedbackTypeError];
+        } else {
+            // Fallback on earlier versions
+        }
     });
 #endif
 }
@@ -813,7 +833,11 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
             
             // Tell the Haptics Generator to prepare for feedback, which may come soon
 #if TARGET_OS_IOS && __IPHONE_OS_VERSION_MAX_ALLOWED >= 100000
-            [strongSelf.hapticGenerator prepare];
+            if (@available(iOS 10_0, *)) {
+                [strongSelf.hapticGenerator prepare];
+            } else {
+                // Fallback on earlier versions
+            }
 #endif
         }
     }];
@@ -1404,7 +1428,7 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
 }
 
 #if TARGET_OS_IOS && __IPHONE_OS_VERSION_MAX_ALLOWED >= 100000
-- (UINotificationFeedbackGenerator *)hapticGenerator {
+- (UINotificationFeedbackGenerator *)hapticGenerator NS_AVAILABLE_IOS(10_0); {
 	// Only return if haptics are enabled
 	if(!self.hapticsEnabled) {
 		return nil;


### PR DESCRIPTION
Remove Compiler Warnings in Xcode 9.0