### PR TITLE
Custom contant frame size

### DIFF
--- a/SVProgressHUD/SVProgressHUD.h
+++ b/SVProgressHUD/SVProgressHUD.h
@@ -70,6 +70,8 @@ typedef void (^SVProgressHUDDismissCompletion)(void);
 @property (assign, nonatomic) NSTimeInterval graceTimeInterval;                             // default is 0 seconds
 @property (assign, nonatomic) NSTimeInterval minimumDismissTimeInterval;                    // default is 5.0 seconds
 @property (assign, nonatomic) NSTimeInterval maximumDismissTimeInterval;                    // default is CGFLOAT_MAX
+@property (assign, nonatomic) CGFloat maximumFrameWidth;                                        // default is 200
+@property (assign, nonatomic) CGFloat maximumFrameHeight;                                       // default is 300
 
 @property (assign, nonatomic) UIOffset offsetFromCenter UI_APPEARANCE_SELECTOR; // default is 0, 0
 
@@ -107,6 +109,8 @@ typedef void (^SVProgressHUDDismissCompletion)(void);
 + (void)setFadeOutAnimationDuration:(NSTimeInterval)duration;       // default is 0.15 seconds
 + (void)setMaxSupportedWindowLevel:(UIWindowLevel)windowLevel;      // default is UIWindowLevelNormal
 + (void)setHapticsEnabled:(BOOL)hapticsEnabled;						// default is NO
++ (void)setMaximumFrameWidth:(CGFloat)newWidth;                     // default is 200
++ (void)setMaximumFrameHeight:(CGFloat)newHeight;                   // default is 300
 
 #pragma mark - Show Methods
 

--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -196,6 +196,14 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
     [self sharedView].hapticsEnabled = hapticsEnabled;
 }
 
++ (void)setMaximumFrameWidth:(CGFloat)newWidth {
+    [self sharedView].maximumFrameWidth = newWidth;
+}
+
++ (void)setMaximumFrameHeight:(CGFloat)newHeight {
+    [self sharedView].maximumFrameHeight = newHeight;
+}
+
 #pragma mark - Show Methods
 
 + (void)show {
@@ -410,6 +418,9 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
         _graceTimeInterval = 0.0f;
         _minimumDismissTimeInterval = 5.0;
         _maximumDismissTimeInterval = CGFLOAT_MAX;
+        
+        _maximumFrameWidth = 200.0;
+        _maximumFrameHeight = 300.0;
 
         _fadeInAnimationDuration = SVProgressHUDDefaultAnimationDuration;
         _fadeOutAnimationDuration = SVProgressHUDDefaultAnimationDuration;
@@ -438,7 +449,7 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
     CGFloat labelWidth = 0.0f;
     
     if(self.statusLabel.text) {
-        CGSize constraintSize = CGSizeMake(200.0f, 300.0f);
+        CGSize constraintSize = CGSizeMake(self.maximumFrameWidth, self.maximumFrameHeight);
         labelRect = [self.statusLabel.text boundingRectWithSize:constraintSize
                                                         options:(NSStringDrawingOptions)(NSStringDrawingUsesFontLeading | NSStringDrawingTruncatesLastVisibleLine | NSStringDrawingUsesLineFragmentOrigin)
                                                      attributes:@{NSFontAttributeName: self.statusLabel.font}


### PR DESCRIPTION
In this PR I changed content frame size to custom, which allows to show more friendly `one line` messages, when message text is long enough (in default 200.0x300.0 frame it could take three-four lines).