### PR TITLE
Image Tint Control

### DIFF
--- a/SVProgressHUD/SVProgressHUD.h
+++ b/SVProgressHUD/SVProgressHUD.h
@@ -63,6 +63,7 @@ typedef void (^SVProgressHUDDismissCompletion)(void);
 @property (strong, nonatomic, nonnull) UIColor *foregroundColor UI_APPEARANCE_SELECTOR;     // default is [UIColor blackColor]
 @property (strong, nonatomic, nonnull) UIColor *backgroundLayerColor UI_APPEARANCE_SELECTOR;// default is [UIColor colorWithWhite:0 alpha:0.4]
 @property (assign, nonatomic) CGSize imageViewSize UI_APPEARANCE_SELECTOR;                  // default is 28x28 pt
+@property (assign, nonatomic) BOOL shouldTintImages UI_APPEARANCE_SELECTOR;                 // default is true
 @property (strong, nonatomic, nonnull) UIImage *infoImage UI_APPEARANCE_SELECTOR;           // default is the bundled info image provided by Freepik
 @property (strong, nonatomic, nonnull) UIImage *successImage UI_APPEARANCE_SELECTOR;        // default is the bundled success image provided by Freepik
 @property (strong, nonatomic, nonnull) UIImage *errorImage UI_APPEARANCE_SELECTOR;          // default is the bundled error image provided by Freepik
@@ -96,6 +97,7 @@ typedef void (^SVProgressHUDDismissCompletion)(void);
 + (void)setBackgroundColor:(nonnull UIColor*)color;                 // default is [UIColor whiteColor], only used for SVProgressHUDStyleCustom
 + (void)setBackgroundLayerColor:(nonnull UIColor*)color;            // default is [UIColor colorWithWhite:0 alpha:0.5], only used for SVProgressHUDMaskTypeCustom
 + (void)setImageViewSize:(CGSize)size;                              // default is 28x28 pt
++ (void)setShouldTintImages:(BOOL)shouldTintImages;                 // default is true
 + (void)setInfoImage:(nonnull UIImage*)image;                       // default is the bundled info image provided by Freepik
 + (void)setSuccessImage:(nonnull UIImage*)image;                    // default is the bundled success image provided by Freepik
 + (void)setErrorImage:(nonnull UIImage*)image;                      // default is the bundled error image provided by Freepik

--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -149,7 +149,11 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
 }
 
 + (void)setImageViewSize:(CGSize)size {
-	[self sharedView].imageViewSize = size;
+    [self sharedView].imageViewSize = size;
+}
+
++ (void)setShouldTintImages:(BOOL)shouldTintImages {
+    [self sharedView].shouldTintImages = shouldTintImages;
 }
 
 + (void)setInfoImage:(UIImage*)image {
@@ -395,9 +399,11 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
         UIImage* successImage = [UIImage imageWithContentsOfFile:[imageBundle pathForResource:@"success" ofType:@"png"]];
         UIImage* errorImage = [UIImage imageWithContentsOfFile:[imageBundle pathForResource:@"error" ofType:@"png"]];
 
-        _infoImage = [infoImage imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
-        _successImage = [successImage imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
-        _errorImage = [errorImage imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+        UIImageRenderingMode renderingMode = (self.shouldTintImages) ? UIImageRenderingModeAlwaysTemplate : UIImageRenderingModeAlwaysOriginal;
+
+        _infoImage = [infoImage imageWithRenderingMode:renderingMode];
+        _successImage = [successImage imageWithRenderingMode:renderingMode];
+        _errorImage = [errorImage imageWithRenderingMode:renderingMode];
 
         _ringThickness = 2.0f;
         _ringRadius = 18.0f;
@@ -860,8 +866,17 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
             [strongSelf cancelIndefiniteAnimatedViewAnimation];
             
             // Update imageView
-            strongSelf.imageView.tintColor = strongSelf.foregroundColorForStyle;
-            strongSelf.imageView.image = image;
+            UIColor *tintColor = strongSelf.foregroundColorForStyle;
+            UIImage *tintedImage = image;
+
+            if (self.shouldTintImages) {
+                if (image.renderingMode != UIImageRenderingModeAlwaysTemplate) {
+                    tintedImage = [image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+                }
+                strongSelf.imageView.tintColor = tintColor;
+            }
+
+            strongSelf.imageView.image = tintedImage;
             strongSelf.imageView.hidden = NO;
             
             // Update text
@@ -1496,6 +1511,10 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
 
 - (void)setBackgroundLayerColor:(UIColor*)color {
     if (!_isInitializing) _backgroundLayerColor = color;
+}
+
+- (void)setShouldTintImages:(BOOL)shouldTintImages {
+    if (!_isInitializing) _shouldTintImages = shouldTintImages;
 }
 
 - (void)setInfoImage:(UIImage*)image {


### PR DESCRIPTION
This PR introduces a new appearance selector called `shouldTintImages`, which is `true` by default.
With this selector one will be able to control image rendering mode, e.g. if it's set to true `Always Template` mode with applied tint will be used, otherwise, it would be an `Always Original` mode.
This is very helpful if you have info/error/success images in different colors.