### PR TITLE
Fix bug where status label hiddenness is not updated when setStatus is called

### DIFF
--- a/Demo/Base.lproj/Main.storyboard
+++ b/Demo/Base.lproj/Main.storyboard
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -23,13 +23,13 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SVProgressHUD" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sGh-mU-or6">
-                                <rect key="frame" x="16" y="50" width="343" height="33.5"/>
+                                <rect key="frame" x="16" y="27.5" width="343" height="33.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="28"/>
                                 <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kdO-6H-glK">
-                                <rect key="frame" x="16" y="94.5" width="343" height="33"/>
+                                <rect key="frame" x="16" y="72.5" width="343" height="33"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <state key="normal" title="show"/>
                                 <connections>
@@ -37,7 +37,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ajX-aT-XVa">
-                                <rect key="frame" x="16" y="139" width="343" height="33"/>
+                                <rect key="frame" x="16" y="117" width="343" height="33"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <state key="normal" title="showWithStatus:">
                                     <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
@@ -47,7 +47,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="X7s-1O-DUR">
-                                <rect key="frame" x="16" y="272.5" width="343" height="33"/>
+                                <rect key="frame" x="16" y="250.5" width="343" height="33"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <state key="normal" title="showSuccessWithStatus:">
                                     <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
@@ -57,7 +57,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1bX-FJ-Xml">
-                                <rect key="frame" x="16" y="228" width="343" height="33"/>
+                                <rect key="frame" x="16" y="206" width="343" height="33"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <state key="normal" title="showInfoWithStatus:">
                                     <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
@@ -67,7 +67,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QWC-hg-lSh">
-                                <rect key="frame" x="16" y="317" width="343" height="33"/>
+                                <rect key="frame" x="16" y="295" width="343" height="33"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <state key="normal" title="showErrorWithStatus:">
                                     <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
@@ -77,7 +77,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="XgO-m1-d5S">
-                                <rect key="frame" x="16" y="183.5" width="343" height="33"/>
+                                <rect key="frame" x="16" y="161.5" width="343" height="33"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <state key="normal" title="showWithProgress:">
                                     <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
@@ -87,7 +87,7 @@
                                 </connections>
                             </button>
                             <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="hhM-GA-UeK">
-                                <rect key="frame" x="16" y="497.5" width="91" height="29"/>
+                                <rect key="frame" x="16" y="519.5" width="91" height="29"/>
                                 <segments>
                                     <segment title="Light"/>
                                     <segment title="Dark"/>
@@ -97,7 +97,7 @@
                                 </connections>
                             </segmentedControl>
                             <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="iAW-K3-Ahn">
-                                <rect key="frame" x="252" y="497.5" width="107" height="29"/>
+                                <rect key="frame" x="252" y="519.5" width="107" height="29"/>
                                 <segments>
                                     <segment title="Flat"/>
                                     <segment title="Native"/>
@@ -107,25 +107,25 @@
                                 </connections>
                             </segmentedControl>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Style" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3Eo-qS-Rfh">
-                                <rect key="frame" x="16" y="453.5" width="48" height="27"/>
+                                <rect key="frame" x="16" y="475.5" width="48" height="27"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="22"/>
                                 <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="MaskType" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Duh-O6-gih">
-                                <rect key="frame" x="16" y="542.5" width="343" height="27"/>
+                                <rect key="frame" x="16" y="564.5" width="343" height="27"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="22"/>
                                 <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="AnimationType" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JME-9t-3qr">
-                                <rect key="frame" x="220" y="453.5" width="139" height="27"/>
+                                <rect key="frame" x="220" y="475.5" width="139" height="27"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="22"/>
                                 <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="a46-EJ-vvy">
-                                <rect key="frame" x="16" y="586.5" width="343" height="29"/>
+                                <rect key="frame" x="16" y="608.5" width="343" height="29"/>
                                 <segments>
                                     <segment title="None"/>
                                     <segment title="Clear"/>
@@ -138,7 +138,7 @@
                                 </connections>
                             </segmentedControl>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7ND-R8-KBh">
-                                <rect key="frame" x="0.0" y="406" width="375" height="33"/>
+                                <rect key="frame" x="0.0" y="428" width="375" height="33"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <state key="normal" title="popActivity - 0">
                                     <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
@@ -148,7 +148,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2U6-gA-atj">
-                                <rect key="frame" x="16" y="361.5" width="343" height="33"/>
+                                <rect key="frame" x="16" y="383.5" width="343" height="33"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <state key="normal" title="dismiss">
                                     <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
@@ -157,49 +157,62 @@
                                     <action selector="dismiss" destination="BYZ-38-t0r" eventType="touchUpInside" id="0RS-fP-GIf"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="JSx-hX-xEg">
+                                <rect key="frame" x="16" y="339" width="343" height="33"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                <state key="normal" title="setStatus:">
+                                    <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                                </state>
+                                <connections>
+                                    <action selector="setStatus:" destination="BYZ-38-t0r" eventType="touchUpInside" id="nFK-T4-ZdI"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstItem="JME-9t-3qr" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" multiplier="21/15" id="1ZU-Qp-f3s"/>
+                            <constraint firstItem="JME-9t-3qr" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" multiplier="22/15" id="1ZU-Qp-f3s"/>
                             <constraint firstItem="hhM-GA-UeK" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" id="1Zu-DW-11b"/>
                             <constraint firstItem="a46-EJ-vvy" firstAttribute="trailing" secondItem="8bC-Xf-vdC" secondAttribute="trailingMargin" id="28G-5d-jY0"/>
-                            <constraint firstItem="QWC-hg-lSh" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" multiplier="15/15" id="2L9-Fg-VRL"/>
+                            <constraint firstItem="QWC-hg-lSh" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" multiplier="14/15" id="2L9-Fg-VRL"/>
                             <constraint firstItem="Duh-O6-gih" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" id="4IA-m9-fws"/>
                             <constraint firstItem="1bX-FJ-Xml" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" id="53b-Fp-k8D"/>
-                            <constraint firstItem="XgO-m1-d5S" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" multiplier="9/15" id="7Bm-rv-iZF"/>
-                            <constraint firstItem="ajX-aT-XVa" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" multiplier="7/15" id="8AZ-lA-S8r"/>
-                            <constraint firstItem="1bX-FJ-Xml" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" multiplier="11/15" id="8Ir-Pr-MnM"/>
+                            <constraint firstItem="XgO-m1-d5S" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" multiplier="8/15" id="7Bm-rv-iZF"/>
+                            <constraint firstItem="ajX-aT-XVa" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" multiplier="6/15" id="8AZ-lA-S8r"/>
+                            <constraint firstItem="1bX-FJ-Xml" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" multiplier="10/15" id="8Ir-Pr-MnM"/>
+                            <constraint firstItem="JSx-hX-xEg" firstAttribute="trailing" secondItem="8bC-Xf-vdC" secondAttribute="trailingMargin" id="Bmp-fo-Jyr"/>
                             <constraint firstItem="kdO-6H-glK" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" id="D0h-dQ-qgN"/>
                             <constraint firstItem="sGh-mU-or6" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" id="EaC-8O-j3a"/>
-                            <constraint firstItem="kdO-6H-glK" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" multiplier="5/15" id="F8I-oY-lJg"/>
+                            <constraint firstItem="kdO-6H-glK" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" multiplier="4/15" id="F8I-oY-lJg"/>
                             <constraint firstItem="2U6-gA-atj" firstAttribute="trailing" secondItem="8bC-Xf-vdC" secondAttribute="trailingMargin" id="FdN-2m-UnI"/>
                             <constraint firstItem="iAW-K3-Ahn" firstAttribute="trailing" secondItem="8bC-Xf-vdC" secondAttribute="trailingMargin" id="Q8b-mS-LWw"/>
                             <constraint firstItem="7ND-R8-KBh" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leading" id="QYS-S8-xLU"/>
-                            <constraint firstItem="a46-EJ-vvy" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" multiplier="27/15" id="R3B-vN-g6y"/>
+                            <constraint firstItem="a46-EJ-vvy" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" multiplier="28/15" id="R3B-vN-g6y"/>
                             <constraint firstItem="2U6-gA-atj" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" id="U70-CM-vGK"/>
+                            <constraint firstItem="JSx-hX-xEg" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" id="UXL-lP-pqJ"/>
                             <constraint firstItem="QWC-hg-lSh" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" id="VnX-Km-Zwo"/>
                             <constraint firstItem="3Eo-qS-Rfh" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" id="WGc-bk-MvY"/>
-                            <constraint firstItem="hhM-GA-UeK" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" multiplier="23/15" id="WIW-JE-Jsi"/>
+                            <constraint firstItem="hhM-GA-UeK" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" multiplier="24/15" id="WIW-JE-Jsi"/>
                             <constraint firstItem="JME-9t-3qr" firstAttribute="trailing" secondItem="8bC-Xf-vdC" secondAttribute="trailingMargin" id="WnK-2H-9P7"/>
                             <constraint firstItem="X7s-1O-DUR" firstAttribute="trailing" secondItem="8bC-Xf-vdC" secondAttribute="trailingMargin" id="aHG-Ae-oWY"/>
                             <constraint firstItem="QWC-hg-lSh" firstAttribute="trailing" secondItem="8bC-Xf-vdC" secondAttribute="trailingMargin" id="bdx-ji-2yy"/>
                             <constraint firstAttribute="trailing" secondItem="7ND-R8-KBh" secondAttribute="trailing" id="d0q-5A-QdV"/>
                             <constraint firstItem="ajX-aT-XVa" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" id="hex-9h-WjG"/>
                             <constraint firstItem="XgO-m1-d5S" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" id="iAg-a2-xDH"/>
-                            <constraint firstItem="7ND-R8-KBh" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" multiplier="19/15" id="ihP-XN-FIA"/>
+                            <constraint firstItem="7ND-R8-KBh" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" multiplier="20/15" id="ihP-XN-FIA"/>
                             <constraint firstItem="X7s-1O-DUR" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" id="klo-EU-U3f"/>
                             <constraint firstItem="ajX-aT-XVa" firstAttribute="trailing" secondItem="8bC-Xf-vdC" secondAttribute="trailingMargin" id="mU6-5b-WKz"/>
-                            <constraint firstItem="3Eo-qS-Rfh" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" multiplier="21/15" id="nvR-0E-Gi7"/>
+                            <constraint firstItem="3Eo-qS-Rfh" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" multiplier="22/15" id="nvR-0E-Gi7"/>
                             <constraint firstItem="sGh-mU-or6" firstAttribute="trailing" secondItem="8bC-Xf-vdC" secondAttribute="trailingMargin" id="nyG-xK-bfg"/>
+                            <constraint firstItem="JSx-hX-xEg" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" multiplier="16/15" id="pWd-h8-SmN"/>
                             <constraint firstItem="XgO-m1-d5S" firstAttribute="trailing" secondItem="8bC-Xf-vdC" secondAttribute="trailingMargin" id="pZ6-jL-Bjc"/>
                             <constraint firstItem="1bX-FJ-Xml" firstAttribute="trailing" secondItem="8bC-Xf-vdC" secondAttribute="trailingMargin" id="qkB-yb-nrT"/>
-                            <constraint firstItem="2U6-gA-atj" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" multiplier="17/15" id="qnC-NT-OP6"/>
+                            <constraint firstItem="2U6-gA-atj" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" multiplier="18/15" id="qnC-NT-OP6"/>
                             <constraint firstItem="Duh-O6-gih" firstAttribute="trailing" secondItem="8bC-Xf-vdC" secondAttribute="trailingMargin" id="r4b-RR-n8m"/>
-                            <constraint firstItem="sGh-mU-or6" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" multiplier="3/15" id="r6M-pq-dnJ"/>
-                            <constraint firstItem="Duh-O6-gih" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" multiplier="25/15" id="uMK-VD-lbc"/>
+                            <constraint firstItem="sGh-mU-or6" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" multiplier="2/15" id="r6M-pq-dnJ"/>
+                            <constraint firstItem="Duh-O6-gih" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" multiplier="26/15" id="uMK-VD-lbc"/>
                             <constraint firstItem="kdO-6H-glK" firstAttribute="trailing" secondItem="8bC-Xf-vdC" secondAttribute="trailingMargin" id="wE4-s6-bav"/>
-                            <constraint firstItem="iAW-K3-Ahn" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" multiplier="23/15" id="x4G-gF-8I7"/>
-                            <constraint firstItem="X7s-1O-DUR" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" multiplier="13/15" id="y2m-6W-g8C"/>
+                            <constraint firstItem="iAW-K3-Ahn" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" multiplier="24/15" id="x4G-gF-8I7"/>
+                            <constraint firstItem="X7s-1O-DUR" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" multiplier="12/15" id="y2m-6W-g8C"/>
                             <constraint firstItem="a46-EJ-vvy" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" id="zqM-IZ-LrD"/>
                         </constraints>
                     </view>

--- a/Demo/Classes/ViewController.m
+++ b/Demo/Classes/ViewController.m
@@ -105,6 +105,11 @@ static float progress = 0.0f;
     }
 }
 
+#pragma mark - Set Status Sample
+
+- (IBAction)setStatus:(id)sender {
+    [SVProgressHUD setStatus:@"New Status"];
+}
 
 #pragma mark - Dismiss Methods Sample
 

--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -506,7 +506,8 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
     }
     self.statusLabel.frame = labelRect;
     self.statusLabel.center = CGPointMake(CGRectGetMidX(self.hudView.bounds), centerY);
-    
+    self.statusLabel.hidden = self.statusLabel.text.length == 0;
+
     [CATransaction commit];
 }
 


### PR DESCRIPTION
## Summary of changes
- Fix the aforementioned bug
- Add demo for `setStatus` method
## Issue
When `setStatus` is called after `show`, the status label is still hidden while space is reserved
## Cause
In `updateHUDFrame`, `self.statusLabel.hidden` is not updated while text has changed
## Fix
Add line to update `self.statusLabel.hidden` in `updateHUDFrame`
## Demo
### Before the fix
![svprogresshud_bug_before](https://user-images.githubusercontent.com/11769136/34582352-852b3b74-f1ce-11e7-9c67-d4517de338bb.gif)
### After the fix
![svprogresshud_bug_after](https://user-images.githubusercontent.com/11769136/34582404-a30711b8-f1ce-11e7-9f25-60b0c4c420a0.gif)