### PR TITLE
Show statusLabel when text is added to it.

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -565,6 +565,7 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
 
 - (void)setStatus:(NSString*)status {
     self.statusLabel.text = status;
+    self.statusLabel.hidden = status.length == 0;
     [self updateHUDFrame];
 }
 


### PR DESCRIPTION
- Fixes an issue where the status would not be shown if it was added to a version of the HUD without any text.
- PR follow up from https://github.com/SVProgressHUD/SVProgressHUD/pull/854.