### PR TITLE
Fixed Issue #837 (accessibility hierarchy problem)

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -879,6 +879,7 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
     } else {
         self.controlView.userInteractionEnabled = NO;
         self.hudView.accessibilityLabel = self.statusLabel.text ?: NSLocalizedString(@"Loading", nil);
+        self.isAccessibilityElement = NO;
         self.hudView.isAccessibilityElement = YES;
     }
     


### PR DESCRIPTION
 Setting parent view as an accessible view prevents from finding siblings, so we need to turn it off if we want to use subviews