### PR TITLE
AccessibilityViewIsModal for SVProgressHUDMaskType

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -876,10 +876,12 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
         self.controlView.userInteractionEnabled = YES;
         self.accessibilityLabel = self.statusLabel.text ?: NSLocalizedString(@"Loading", nil);
         self.isAccessibilityElement = YES;
+        self.controlView.accessibilityViewIsModal = YES;
     } else {
         self.controlView.userInteractionEnabled = NO;
         self.hudView.accessibilityLabel = self.statusLabel.text ?: NSLocalizedString(@"Loading", nil);
         self.hudView.isAccessibilityElement = YES;
+        self.controlView.accessibilityViewIsModal = NO;
     }
     
     // Get duration


### PR DESCRIPTION

Issue: Voiceover users are able to access background elements when SVProgressHUDMask is set to anything.

Expectation: Voiceover user should not be able to access background elements when SVProgressHUDMask is set to anything other then None.

Fix: Setting the controlView to accessibilityViewIsModal=YES while !=SVProgressHUDMaskTypeNone blocks the user from accessing background elements with VoiceOver on.