### PR TITLE
Mac Catalyst & the start of Multi-Window Support

### DIFF
--- a/SVProgressHUD.podspec
+++ b/SVProgressHUD.podspec
@@ -15,4 +15,13 @@ Pod::Spec.new do |s|
   s.framework    = 'QuartzCore'
   s.resources    = 'SVProgressHUD/SVProgressHUD.bundle'
   s.requires_arc = true
+
+  s.subspec 'ExtensionSafe' do |sp|
+    sp.compiler_flags = '-D SV_APP_EXTENSIONS'
+    sp.pod_target_xcconfig = { 'SV_APP_EXTENSIONS' => '1' }
+    sp.source_files = 'SVProgressHUD/*.{h,m}'
+    sp.framework    = 'QuartzCore'
+    sp.resources    = 'SVProgressHUD/SVProgressHUD.bundle'
+    sp.requires_arc = true
+  end
 end

--- a/SVProgressHUD/SVProgressHUD.h
+++ b/SVProgressHUD/SVProgressHUD.h
@@ -148,5 +148,25 @@ typedef void (^SVProgressHUDDismissCompletion)(void);
 
 + (NSTimeInterval)displayDurationForString:(nullable NSString*)string;
 
+- (nonnull instancetype)initWithView:(nonnull UIView*)view;
+
+- (NSTimeInterval)displayDurationForString:(nullable NSString*)string;
+
+- (void)showImage:(nonnull UIImage*)image status:(nullable NSString*)status;
+
+- (void)showErrorWithStatus:(nonnull NSString*)status;
+
+- (void)showProgress:(float)progress;
+- (void)showProgress:(float)progress status:(nullable NSString*)status;
+
+- (void)showWithStatus:(nonnull NSString*)status;
+
+- (void)show;
+
+- (void)showSuccessWithStatus:(nonnull NSString*)status;
+
+- (void)showInfoWithStatus:(nonnull NSString*)status;
+- (BOOL)isVisible;
+- (void)dismiss;
 @end
 

--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -536,6 +536,7 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
 #endif
 
 - (void)updateMotionEffectForXMotionEffectType:(UIInterpolatingMotionEffectType)xMotionEffectType yMotionEffectType:(UIInterpolatingMotionEffectType)yMotionEffectType {
+#if !TARGET_OS_MACCATALYST
     UIInterpolatingMotionEffect *effectX = [[UIInterpolatingMotionEffect alloc] initWithKeyPath:@"center.x" type:xMotionEffectType];
     effectX.minimumRelativeValue = @(-SVProgressHUDParallaxDepthPoints);
     effectX.maximumRelativeValue = @(SVProgressHUDParallaxDepthPoints);
@@ -550,6 +551,7 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
     // Clear old motion effect, then add new motion effects
     self.hudView.motionEffects = @[];
     [self.hudView addMotionEffect:effectGroup];
+#endif
 }
 
 - (void)updateViewHierarchy {


### PR DESCRIPTION
We are implementing a Catalyst version of our app, and want to support multiple windows as well.

This starts that process by doing three things:

* Disable unsafe methods in a Catalyst build
* Expose instance functions on SVProgressHUD so you can control N HUDs
* Simplify the use of an extension safe version of SVProgressHUD