### PR TITLE
Fix demo app doesn’t run without CFBundleShortVersionString key

### DIFF
--- a/Demo/SVProgressHUD-Info.plist
+++ b/Demo/SVProgressHUD-Info.plist
@@ -14,6 +14,8 @@
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
Currently when opening Demo/SVProgressHUD.xcodeproj, the iOS Demo scheme cannot be run. An error message indicating the CFBundleShortVersionString key is missing from the Info.plist.