### PR TITLE
The fix for the issue #1002 about HUD not being centralized.

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -573,7 +573,7 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
         // be changed during runtime).
         [self.controlView.superview bringSubviewToFront:self.controlView];
     }
-    
+
     // Add self to the overlay view
     if(!self.superview) {
         [self.controlView addSubview:self];
@@ -685,8 +685,10 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
     }
 #endif
     
+    // for ios 13, the self.bounds wasn't returning the screen value, so I changed to the mainScreen bounds
+    CGRect screenRect = [[UIScreen mainScreen] bounds];
     // Get the currently active frame of the display (depends on orientation)
-    CGRect orientationFrame = self.bounds;
+    CGRect orientationFrame = screenRect;
 
 #if !defined(SV_APP_EXTENSIONS) && TARGET_OS_IOS
     CGRect statusBarFrame = UIApplication.sharedApplication.statusBarFrame;


### PR DESCRIPTION
on iOS 13, `self.bounds `wasn't being recognised. So I changed to the mainScreen instead, which it worked. This helps with the top left corner position issue on iOS 13.

Hope it helps :)
Ariane