### PR TITLE
Add shadow customization to the shared view

### DIFF
--- a/SVProgressHUD/SVProgressHUD.h
+++ b/SVProgressHUD/SVProgressHUD.h
@@ -88,6 +88,10 @@ typedef void (^SVProgressHUDDismissCompletion)(void);
 + (void)setCornerRadius:(CGFloat)cornerRadius;                          // default is 14 pt
 + (void)setBorderColor:(nonnull UIColor*)color;                         // default is nil
 + (void)setBorderWidth:(CGFloat)width;                                  // default is 0
++ (void)setShadowColor:(nonnull UIColor*)color;                         // default is an opaque black color
++ (void)setShadowOffset:(CGSize)size;                                   // default is (0.0, -3.0)
++ (void)setShadowOpacity:(CGFloat)opacity;                              // default is 0.0
++ (void)setShadowRadius:(CGFloat)radius;                                // default is 3.0
 + (void)setFont:(nonnull UIFont*)font;                                  // default is [UIFont preferredFontForTextStyle:UIFontTextStyleSubheadline]
 + (void)setForegroundColor:(nonnull UIColor*)color;                     // default is [UIColor blackColor], only used for SVProgressHUDStyleCustom
 + (void)setForegroundImageColor:(nullable UIColor*)color;               // default is nil == foregroundColor, only used for SVProgressHUDStyleCustom

--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -127,6 +127,22 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
     [self sharedView].hudView.layer.borderWidth = width;
 }
 
++ (void)setShadowColor:(nonnull UIColor*)color {
+    [self sharedView].layer.shadowColor = color.CGColor;
+}
+
++ (void)setShadowOffset:(CGSize)size {
+    [self sharedView].layer.shadowOffset = size;
+}
+
++ (void)setShadowOpacity:(CGFloat)opacity {
+    [self sharedView].layer.shadowOpacity = opacity;
+}
+
++ (void)setShadowRadius:(CGFloat)radius {
+    [self sharedView].layer.shadowRadius = radius;
+}
+
 + (void)setFont:(UIFont*)font {
     [self sharedView].font = font;
 }


### PR DESCRIPTION
Hello there.

I am making this PR because on our project https://github.com/meganz/iOS our designers request us to add some customization to this HUD and to add it some depth from the background views AKA shadow 😄 . I do not know if this could be done with other methods, but just in case you find it useful.

I did not added properties for this layer values because I think they are not necessary. 

I wrote the defaults values that appear on the Apple documentation on the comments of the methods in the header file. 

In case you are interested on this PR, please tell me if I need to add or change anything so you can merge it, if not please feel free to close the PR.

Thank you for your time.

Cheers!

![Example for the shadow](https://user-images.githubusercontent.com/5855504/69583661-446a7400-1040-11ea-9bf9-8a6a5d4beac2.png)