### PR TITLE
Feature/add accessibility announcement enabled property

### DIFF
--- a/SVProgressHUD/SVProgressHUD.h
+++ b/SVProgressHUD/SVProgressHUD.h
@@ -77,6 +77,8 @@ typedef void (^SVProgressHUDDismissCompletion)(void);
 @property (assign, nonatomic) BOOL hapticsEnabled;      // default is NO
 @property (assign, nonatomic) BOOL motionEffectEnabled; // default is YES
 
+@property (assign, nonatomic) BOOL accessibilityAnnouncementEnabled; // default is YES
+
 + (void)setDefaultStyle:(SVProgressHUDStyle)style;                      // default is SVProgressHUDStyleLight
 + (void)setDefaultMaskType:(SVProgressHUDMaskType)maskType;             // default is SVProgressHUDMaskTypeNone
 + (void)setDefaultAnimationType:(SVProgressHUDAnimationType)type;       // default is SVProgressHUDAnimationTypeFlat
@@ -106,8 +108,10 @@ typedef void (^SVProgressHUDDismissCompletion)(void);
 + (void)setFadeInAnimationDuration:(NSTimeInterval)duration;            // default is 0.15 seconds
 + (void)setFadeOutAnimationDuration:(NSTimeInterval)duration;           // default is 0.15 seconds
 + (void)setMaxSupportedWindowLevel:(UIWindowLevel)windowLevel;          // default is UIWindowLevelNormal
-+ (void)setHapticsEnabled:(BOOL)hapticsEnabled;						    // default is NO
++ (void)setHapticsEnabled:(BOOL)hapticsEnabled;                            // default is NO
 + (void)setMotionEffectEnabled:(BOOL)motionEffectEnabled;               // default is YES
+
++ (void)setAccessibilityAnnouncementEnabled:(BOOL)accessibilityAnnouncementEnabled; // default is YES
 
 #pragma mark - Show Methods
 

--- a/SVProgressHUD/SVProgressHUD.h
+++ b/SVProgressHUD/SVProgressHUD.h
@@ -108,7 +108,7 @@ typedef void (^SVProgressHUDDismissCompletion)(void);
 + (void)setFadeInAnimationDuration:(NSTimeInterval)duration;            // default is 0.15 seconds
 + (void)setFadeOutAnimationDuration:(NSTimeInterval)duration;           // default is 0.15 seconds
 + (void)setMaxSupportedWindowLevel:(UIWindowLevel)windowLevel;          // default is UIWindowLevelNormal
-+ (void)setHapticsEnabled:(BOOL)hapticsEnabled;                            // default is NO
++ (void)setHapticsEnabled:(BOOL)hapticsEnabled;                         // default is NO
 + (void)setMotionEffectEnabled:(BOOL)motionEffectEnabled;               // default is YES
 
 + (void)setAccessibilityAnnouncementEnabled:(BOOL)accessibilityAnnouncementEnabled; // default is YES

--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -211,6 +211,10 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
     [self sharedView].motionEffectEnabled = motionEffectEnabled;
 }
 
++ (void)setAccessibilityAnnouncementEnabled:(BOOL)accessibilityAnnouncementEnabled {
+    [self sharedView].accessibilityAnnouncementEnabled = accessibilityAnnouncementEnabled;
+}
+
 #pragma mark - Show Methods
 
 + (void)show {
@@ -442,6 +446,7 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
         _motionEffectEnabled = YES;
         
         // Accessibility support
+        _accessibilityAnnouncementEnabled = YES;
         self.accessibilityIdentifier = @"SVProgressHUD";
         self.isAccessibilityElement = YES;
         
@@ -938,8 +943,10 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
                                                                   userInfo:[self notificationUserInfo]];
                 
                 // Update accessibility
-                UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, nil);
-                UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, self.statusLabel.text);
+                if (_accessibilityAnnouncementEnabled) {
+                    UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, nil);
+                    UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, self.statusLabel.text);
+                }
                 
                 // Dismiss automatically if a duration was passed as userInfo. We start a timer
                 // which then will call dismiss after the predefined duration
@@ -970,8 +977,10 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
         [self setNeedsDisplay];
     } else {
         // Update accessibility
-        UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, nil);
-        UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, self.statusLabel.text);
+        if (_accessibilityAnnouncementEnabled) {
+            UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, nil);
+            UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, self.statusLabel.text);
+        }
         
         // Dismiss automatically if a duration was passed as userInfo. We start a timer
         // which then will call dismiss after the predefined duration


### PR DESCRIPTION
Add **accessibilityAnnouncementEnabled** property (default to YES)

We had problems with VoiceOver repeating the announcement of a transient success message we display when the user copies to the clipboard. 

By setting the new **accessibilityAnnouncementEnabled** to NO we are able to ensure the message is only announced once using the following code in our main app:

```
func presentTransientAlert(message: String) {
    SVProgressHUD.setAccessibilityAnnouncementEnabled(false)
    SVProgressHUD.showSuccess(withStatus: message)
    SVProgressHUD.dismiss(withDelay: 1) {
        SVProgressHUD.setAccessibilityAnnouncementEnabled(true)
    }
}
```