### PR TITLE
Fixed the layout problem in landscape mode.

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -670,15 +670,11 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
     // Get keyboardHeight in regard to current state
     if(notification) {
         NSDictionary* keyboardInfo = [notification userInfo];
-        CGRect keyboardFrame = [keyboardInfo[UIKeyboardFrameBeginUserInfoKey] CGRectValue];
         animationDuration = [keyboardInfo[UIKeyboardAnimationDurationUserInfoKey] doubleValue];
-        
+
         if(notification.name == UIKeyboardWillShowNotification || notification.name == UIKeyboardDidShowNotification) {
-            keyboardHeight = CGRectGetWidth(keyboardFrame);
-            
-            if(UIInterfaceOrientationIsPortrait(orientation)) {
-                keyboardHeight = CGRectGetHeight(keyboardFrame);
-            }
+            CGRect keyboardFrame = [keyboardInfo[UIKeyboardFrameBeginUserInfoKey] CGRectValue];
+            keyboardHeight = CGRectGetHeight(keyboardFrame);
         }
     } else {
         keyboardHeight = self.visibleKeyboardHeight;


### PR DESCRIPTION
I write a simple demo to reproduce the issue. https://github.com/BB9z/SVProgressHUD/tree/keyboard-demo

https://user-images.githubusercontent.com/513082/108320907-611f3880-71fe-11eb-8cc9-94dea6d8dd54.mov

https://github.com/BB9z/SVProgressHUD/tree/keyboard-demo-fixed - contains the fixes result.

The keyboard frame is already rotated for many years. I remember that a long time ago it did need to be handled manually, maybe it’s not needed since iOS 6 or 7.
