### PR TITLE
Update imageUsed judgment conditions when set imageViewSize to zero

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -452,7 +452,7 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
 
 - (void)updateHUDFrame {
     // Check if an image or progress ring is displayed
-    BOOL imageUsed = (self.imageView.image) && !(self.imageView.hidden);
+    BOOL imageUsed = (self.imageView.image) && !(self.imageView.hidden) && (self.imageViewSize.height > 0 && self.imageViewSize.width > 0);
     BOOL progressUsed = self.imageView.hidden;
     
     // Calculate size of string


### PR DESCRIPTION
when I set  setImageViewSize(.zero), hudView will show a top margin

![image](https://user-images.githubusercontent.com/36944885/167397383-1413a5b4-a6db-4475-a493-ef4525aea060.png)

`---------------------------------------------------------------------------------------------------------------------`
After modification
![image](https://user-images.githubusercontent.com/36944885/167397902-8000fcc5-969e-4963-9518-e580bc454657.png)

