### PR TITLE
Add extra check for CarPlay window scene

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -14,10 +14,6 @@
 #import "SVProgressAnimatedView.h"
 #import "SVRadialGradientLayer.h"
 
-#if __has_include(<CarPlay/CarPlay.h>)
-#import <CarPlay/CarPlay.h>
-#endif
-
 NSString * const SVProgressHUDDidReceiveTouchEventNotification = @"SVProgressHUDDidReceiveTouchEventNotification";
 NSString * const SVProgressHUDDidTouchDownInsideNotification = @"SVProgressHUDDidTouchDownInsideNotification";
 NSString * const SVProgressHUDWillDisappearNotification = @"SVProgressHUDWillDisappearNotification";


### PR DESCRIPTION
The `mainWindow` logic does not take into account CarPlay template scenes, causing it to crash when launched from CarPlay.

Exception is as follows: SIGABRT: -[CPTemplateApplicationScene windows]: unrecognized selector sent to instance 0x104d151a0

It crashes because of the assumptions that all `UIScene` instances are of type UIWindowScene. This PR fixes that.