### PR TITLE
Fix warning Umbrella header for module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Version 2.3.2
+* Fix warning Umbrella header for module
+
 ## Version 2.3.1
 * Add missing symlinks for SPM #1112
 

--- a/SVProgressHUD/include/SVIndefiniteAnimatedView.h
+++ b/SVProgressHUD/include/SVIndefiniteAnimatedView.h
@@ -1,1 +1,0 @@
-../SVIndefiniteAnimatedView.h

--- a/SVProgressHUD/include/SVProgressAnimatedView.h
+++ b/SVProgressHUD/include/SVProgressAnimatedView.h
@@ -1,1 +1,0 @@
-../SVProgressAnimatedView.h

--- a/SVProgressHUD/include/SVRadialGradientLayer.h
+++ b/SVProgressHUD/include/SVRadialGradientLayer.h
@@ -1,1 +1,0 @@
-../SVRadialGradientLayer.h


### PR DESCRIPTION
When installing SVProgressHUD via sub-framework (also SwiftPM), I received the following warning:

```bash
Umbrella header for module 'SVProgressHUD' does not include header 'SVIndefiniteAnimatedView.h'
Umbrella header for module 'SVProgressHUD' does not include header 'SVProgressAnimatedView.h'
Umbrella header for module 'SVProgressHUD' does not include header 'SVRadialGradientLayer.h'
```
Umbrella header such as 'SVProgressHUD.h' should import these additional headers to resolve the warning.

This fixes that warning.

@honkmaster 
@tobihagemann 
@juliensaad