### PR TITLE
Don't exclude PrivacyInfo from the SPM bundle

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
             name: "SVProgressHUD",
             dependencies: [],
             path: "SVProgressHUD",
-            exclude: ["SVProgressHUD-Prefix.pch", "PrivacyInfo.xcprivacy"],
+            exclude: ["SVProgressHUD-Prefix.pch"],
             resources: [
                 .copy("SVProgressHUD.bundle"),
                 .copy("PrivacyInfo.xcprivacy")


### PR DESCRIPTION
So now the PrivacyInfo.xcprivacy is included in the bundle (and will be included in the privacy report and noticed by App Store Connect).

<img width="472" alt="image" src="https://github.com/SVProgressHUD/SVProgressHUD/assets/4634735/658edd7c-564e-4b5c-b09c-d6ad627a5a37">