### PR TITLE
Update PrivacyInfo.xcprivacy‘s bundle name to fix naming conflict

### DIFF
--- a/SVProgressHUD.podspec
+++ b/SVProgressHUD.podspec
@@ -19,13 +19,13 @@ Pod::Spec.new do |s|
   s.subspec 'Core' do |core|
     core.source_files = 'SVProgressHUD/*.{h,m}'
     core.resources = ['SVProgressHUD/SVProgressHUD.bundle']
-    core.resource_bundles = {'SVProgressHUD' => ['SVProgressHUD/PrivacyInfo.xcprivacy']}
+    core.resource_bundles = {'SVProgressHUD_Privacy' => ['SVProgressHUD/PrivacyInfo.xcprivacy']}
   end
 
   s.subspec 'AppExtension' do |ext|
     ext.source_files = 'SVProgressHUD/*.{h,m}'
     ext.resources = ['SVProgressHUD/SVProgressHUD.bundle']
-    ext.resource_bundles = {'AppExtension' => ['SVProgressHUD/PrivacyInfo.xcprivacy']}
+    ext.resource_bundles = {'AppExtension_Privacy' => ['SVProgressHUD/PrivacyInfo.xcprivacy']}
     ext.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => 'SV_APP_EXTENSIONS=1' }
   end
 end


### PR DESCRIPTION
Same with PR #1135, but underscore version.