### PR TITLE
CarPlay edge case crash fix

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -84,9 +84,12 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
                 return windowScene.windows.firstObject;
             }
         }
-        // If a window has not been returned by now, the first scene's window is returned (regardless of activationState).
-        UIWindowScene *windowScene = (UIWindowScene *)[[UIApplication sharedApplication].connectedScenes allObjects].firstObject;
-        return windowScene.windows.firstObject;
+        // Fallback: return first available non-CarPlay UIWindowScene regardless of activation state
+        for (UIWindowScene *windowScene in [UIApplication sharedApplication].connectedScenes) {
+            if ([windowScene isKindOfClass:[UIWindowScene class]] && [windowScene.session.role isEqualToString:UIWindowSceneSessionRoleApplication]) {
+                return windowScene.windows.firstObject;
+            }
+        }
     } else {
 #if TARGET_OS_IOS
         return [[[UIApplication sharedApplication] delegate] window];

--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -80,7 +80,7 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
 + (UIWindow *)mainWindow {
     if (@available(iOS 13.0, *)) {
         for (UIWindowScene* windowScene in [UIApplication sharedApplication].connectedScenes) {
-            if (windowScene.activationState == UISceneActivationStateForegroundActive) {
+            if (windowScene.activationState == UISceneActivationStateForegroundActive && [windowScene.session.role isEqualToString:UIWindowSceneSessionRoleApplication]) {
                 return windowScene.windows.firstObject;
             }
         }


### PR DESCRIPTION
Hi,

I have found this edge case when the app is connected to CarPlay. Here are the steps to reproduce:

1. Run your app from Xcode, but set it to wait for launch
2. Instead of launching the app on your phone, launch it on CarPlay (using CarPlay Simulator, https://developer.apple.com/documentation/carplay/using-the-carplay-simulator)
3. Now, run your app. It will crash, because SVProgresHUD will call functions a property `windows` that doesn't exist in CarPlay window. 

The fix, I think, is verifying this is indeed a UIWindowScene and no a CarPlay window scene (or others).