### PR TITLE
Fix crash when rootViewController is nil during dismiss

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -992,7 +992,9 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
                     // Tell the rootViewController to update the StatusBar appearance
 #if !defined(SV_APP_EXTENSIONS) && TARGET_OS_IOS
                     UIViewController *rootController = [SVProgressHUD mainWindow].rootViewController;
-                    [rootController setNeedsStatusBarAppearanceUpdate];
+                    if (rootController) {
+                        [rootController setNeedsStatusBarAppearanceUpdate];
+                    }
 #endif
                     
                     // Run an (optional) completionHandler


### PR DESCRIPTION
## Summary

Fixes #1155

Adds a nil check before calling `setNeedsStatusBarAppearanceUpdate` on the rootViewController in the dismiss animation completion block.

## Problem

When SVProgressHUD is dismissed, the animation completion block retrieves the rootViewController and calls `setNeedsStatusBarAppearanceUpdate` on it. If the rootViewController has been deallocated (e.g., during view controller transitions), this causes a crash.

## Solution

Simple nil check before the method call:

```objc
UIViewController *rootController = [SVProgressHUD mainWindow].rootViewController;
if (rootController) {
    [rootController setNeedsStatusBarAppearanceUpdate];
}
```

## Testing

- Verified the fix compiles correctly
- The status bar appearance update is a visual nicety, not critical functionality, so skipping it when rootViewController is nil has no adverse effects