### PR TITLE
Add nil check in updateViewHierarchy before adding to window

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -992,7 +992,9 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
                     // Tell the rootViewController to update the StatusBar appearance
 #if !defined(SV_APP_EXTENSIONS) && TARGET_OS_IOS
                     UIViewController *rootController = [SVProgressHUD mainWindow].rootViewController;
-                    [rootController setNeedsStatusBarAppearanceUpdate];
+                    if (rootController) {
+                        [rootController setNeedsStatusBarAppearanceUpdate];
+                    }
 #endif
                     
                     // Run an (optional) completionHandler

--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -516,7 +516,10 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
             [self.containerView addSubview:self.controlView];
         } else {
 #if !defined(SV_APP_EXTENSIONS)
-            [self.frontWindow addSubview:self.controlView];
+            UIWindow *window = self.frontWindow;
+            if (window.rootViewController) {
+                [window addSubview:self.controlView];
+            }
 #else
             // If SVProgressHUD is used inside an app extension add it to the given view
             if(self.viewForExtension) {

--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -517,7 +517,7 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
         } else {
 #if !defined(SV_APP_EXTENSIONS)
             UIWindow *window = self.frontWindow;
-            if (window.rootViewController) {
+            if (window && window.rootViewController) {
                 [window addSubview:self.controlView];
             }
 #else


### PR DESCRIPTION
## Summary

Fixes #1157

Adds a nil check for `rootViewController` before adding the control view to the window in `updateViewHierarchy`.

## Problem

When SVProgressHUD is shown, it adds its control view to the front window. If the window exists but has no `rootViewController` (or it's in an invalid state during app transitions), UIKit throws an `NSInternalInconsistencyException` when resolving trait collection for the new subview.

## Solution

Check that `window.rootViewController` is not nil before adding the subview:

```objc
UIWindow *window = self.frontWindow;
if (window.rootViewController) {
    [window addSubview:self.controlView];
}
```

## Testing

- Verified the fix compiles correctly
- If no valid window is available, the HUD simply won't be shown (graceful degradation)